### PR TITLE
Remove dependency on pulumi.Input/Output from docker.ts

### DIFF
--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -76,9 +76,23 @@ export interface DockerBuild {
     cacheFrom?: boolean | CacheFrom;
 }
 
-// buildAndPushImage will build and push the Dockerfile and context from [buildPath] into the requested ECR
-// [repository].  It returns the digest of the built image.
-export async function buildAndPushImage(
+/**
+ * @deprecated Use [buildAndPushImageAsync] instead.
+ */
+export function buildAndPushImage(
+    imageName: string,
+    pathOrBuild: string | DockerBuild,
+    repositoryUrl: pulumi.Input<string>,
+    logResource: pulumi.Resource,
+    connectToRegistry: () => Promise<Registry>): pulumi.Output<string> {
+
+    return pulumi.output(repositoryUrl).apply(repoUrl =>
+        buildAndPushImageAsync(imageName, pathOrBuild, repoUrl, logResource, connectToRegistry));
+}
+
+// buildAndPushImageAsync will build and push the Dockerfile and context from [buildPath] into the
+// requested ECR [repositoryUrl].  It returns the digest of the built image.
+export async function buildAndPushImageAsync(
     imageName: string,
     pathOrBuild: string | DockerBuild,
     repositoryUrl: string,


### PR DESCRIPTION
Thanks to https://github.com/pulumi/pulumi-docker/pull/5 and https://github.com/pulumi/pulumi-cloud/pull/547 we no longer have any need to handle actual `Input`s or produce `Output`s at this layer.  

Note: this is a breaking change as it will require that someone using pulumi-cloud have https://github.com/pulumi/pulumi-cloud/pull/547 merged in.  Since this is an internal library, i think that's fine.  but we shoudl likely wait until our *next* upcoming release to have this go in.