### PR TITLE
Revert buildAndPushImageAsync to return Id instead of Digest

### DIFF
--- a/docker/index.ts
+++ b/docker/index.ts
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from "./docker";
+export { buildAndPushImage, buildAndPushImageAsync, CacheFrom, DockerBuild, Registry } from "./docker";
 export * from "./image";


### PR DESCRIPTION
In #10, we "fixed" buildAndPushAsync to return the image repo digest instead of the image id.  The former is more useful as it can be applied as a digest version to pin a specific built image and force updates when that image changes.

However, the repo digest is not available for images that have not yet been pushed/pulled from a repository.  Moreover, the repo digest must be looked up by the repo-tagged name (and apparently the digest can differ across repos even for the same image), not by a local-only tag.

The combination of these two factors broke the way we use `pulumi-docker` from `pulumi-cloud`, and introduced the bug in pulumi/pulumi-cloud#595 where the `IMAGE_DIGEST` env var was always getting set to an empty string.  (notably, that env var is misnamed, it was previously the Image Id).

The safest fix for now is to return to how this worked until recently - return the Image Id from `buildAndPushImageAsync`.

To support the `docker.Image` case where we want to compute a pinned repo image name, we move the logic for getting the digest into a separate helper, and use it only in `docker.Image`.

We may want to unify these two paths further, and find a reliable way to use the real digest in both cases - including removing the env var approach used in `pulumi-cloud` and replacing it with the pinned image name approach used in `docker.Image`.  However, given that this digest cannot be computed until a push - and we skip pushes in preview - I'm sufficiently nervous that this will lead to very noisy previews.  And I don't currently know if/how we can avoid that.

This mostly addresses pulumi/pulumi-cloud#595, but will need to pull this fix into pulumi-cloud.