### PR TITLE
make docker registry credentials optional

### DIFF
--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -133,13 +133,19 @@ export async function buildAndPushImageAsync(
     pathOrBuild: string | DockerBuild,
     repositoryUrl: string,
     logResource: pulumi.Resource,
-    connectToRegistry: () => Promise<Registry>): Promise<string> {
+    connectToRegistry?: () => Promise<Registry>): Promise<string> {
 
     let loggedIn: Promise<void> | undefined;
+
+    // If no `connectToRegistry` function was passed in we simply assume docker is already logged-in to the correct registry (or uses auto-login via credential helpers)
+    // hence we resolve loggedIn immediately.
+    if (!connectToRegistry) {
+        loggedIn = Promise.resolve();
+    }
     const login = () => {
         if (!loggedIn) {
             pulumi.log.info("logging in to registry...", logResource);
-            loggedIn = connectToRegistry().then(r => loginToRegistry(r, logResource));
+            loggedIn = connectToRegistry!().then(r => loginToRegistry(r, logResource));
         }
         return loggedIn;
     };

--- a/docker/image.ts
+++ b/docker/image.ts
@@ -33,9 +33,9 @@ export interface ImageArgs {
      */
     localImageName?: pulumi.Input<string>;
     /**
-     * Docker registry to push to.
+     * Credentials for the docker registry to push to.
      */
-    registry: pulumi.Input<ImageRegistry>;
+    registry?: pulumi.Input<ImageRegistry>;
 }
 
 export interface ImageRegistry {
@@ -96,13 +96,13 @@ export class Image extends pulumi.ComponentResource {
                     if (!localImageName) {
                         localImageName = imageName;
                     }
-                    const id = await buildAndPushImageAsync(localImageName, build, imageName, this, async () => {
+                    const id = await buildAndPushImageAsync(localImageName, build, imageName, this, registry && (async () => {
                         return {
                             registry: registryServer,
                             username: username,
                             password: password,
                         };
-                    });
+                    }));
                     const digest = await getDigest(imageName, this);
                     return { digest, id };
                 }));


### PR DESCRIPTION
this is especially useful when using docker credential helpers which already handle auth to the target registry.

fixes #16 