### PR TITLE
Only print out docker messages in the event of warnings/failures.

### DIFF
--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -234,7 +234,7 @@ async function pullCacheAsync(
         // Try to pull the existing image if it exists.  This may fail if the image does not exist.
         // That's fine, just move onto the next sage.
         const { code, stdout } = await runCommandThatCanFail(
-            "docker", ["pull", image], logResource, /*reportFullCommandLine:*/ true);
+            "docker", ["pull", image], logResource, /*reportFullCommand:*/ true);
         if (code) {
             continue;
         }
@@ -303,8 +303,7 @@ async function buildImageAsync(
     // Finally, inspect the image so we can return the SHA digest. Do not forward the output of this
     // command this to the CLI to show the user.
     const inspectResult = await runCommandThatMustSucceed(
-        "docker", ["image", "inspect", "-f", "{{.Id}}", imageName],
-        logResource, /*reportFullCommandLine*/ true);
+        "docker", ["image", "inspect", "-f", "{{.Id}}", imageName], logResource);
     if (!inspectResult) {
        throw new ResourceError(
            `No digest available for image ${imageName}`, logResource);
@@ -346,8 +345,7 @@ async function dockerBuild(
         buildArgs.push(...[ "--target", target ]);
     }
 
-    await runCommandThatMustSucceed(
-        "docker", buildArgs, logResource, /*reportFullCommandLine*/ true);
+    await runCommandThatMustSucceed("docker", buildArgs, logResource);
 }
 
 async function loginToRegistry(registry: Registry, logResource: pulumi.Resource): Promise<void> {
@@ -380,11 +378,8 @@ async function pushImageAsync(
     tag = tag ? `:${tag}` : "";
     const targetImage = `${repositoryUrl}${tag}`;
 
-    await runCommandThatMustSucceed(
-        "docker", ["tag", imageName, targetImage], logResource, /*reportFullCommandLine*/ true);
-
-    await runCommandThatMustSucceed(
-        "docker", ["push", targetImage], logResource, /*reportFullCommandLine*/ true);
+    await runCommandThatMustSucceed("docker", ["tag", imageName, targetImage], logResource);
+    await runCommandThatMustSucceed("docker", ["push", targetImage], logResource);
 }
 
 // getDigest returns the digest, if available, of a target image.  The digest will only be available once the repo image
@@ -392,8 +387,7 @@ async function pushImageAsync(
 export async function getDigest(targetImage: string, logResource: pulumi.Resource): Promise<string | undefined> {
     // Do not forward the output of this command this to the CLI to show the user.
 
-    const inspectResult = await runCommandThatMustSucceed(
-        "docker", ["image", "inspect", targetImage], logResource, /*reportFullCommandLine*/ true);
+    const inspectResult = await runCommandThatMustSucceed("docker", ["image", "inspect", targetImage], logResource);
     if (!inspectResult) {
         throw new ResourceError(
             `No digest available for image ${targetImage}`, logResource);

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -124,7 +124,7 @@ export function buildAndPushImage(
         buildAndPushImageAsync(imageName, pathOrBuild, repoUrl, logResource, connectToRegistry));
 }
 
-function logEphemeral(message: string, logResource: pulumi.Resource | undefined) {
+function logEphemeral(message: string, logResource: pulumi.Resource) {
     pulumi.log.info(message, logResource, /*streamId:*/ undefined, /*ephemeral:*/ true);
 }
 
@@ -443,7 +443,7 @@ function getFailureMessage(cmd: string, args: string[], reportFullCommandLine: b
 async function runCommandThatMustSucceed(
     cmd: string,
     args: string[],
-    logResource: pulumi.Resource | undefined,
+    logResource: pulumi.Resource,
     reportFullCommandLine: boolean = true,
     stdin?: string): Promise<string> {
 
@@ -476,7 +476,7 @@ async function runCommandThatMustSucceed(
 async function runCommandThatCanFail(
     cmd: string,
     args: string[],
-    logResource: pulumi.Resource | undefined,
+    logResource: pulumi.Resource,
     reportFullCommandLine: boolean,
     stdin?: string): Promise<CommandResult> {
 

--- a/docker/package.json
+++ b/docker/package.json
@@ -10,7 +10,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-docker",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.4-dev",
+        "@pulumi/pulumi": "dev",
         "semver": "^5.4.0"
     },
     "devDependencies": {

--- a/docker/yarn.lock
+++ b/docker/yarn.lock
@@ -45,9 +45,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/pulumi@^0.15.4-dev":
-  version "0.15.4-dev-1537844791-g431f5b34"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537844791-g431f5b34.tgz#2c3d79515be81ab910f817376d32e8db83783cd3"
+"@pulumi/pulumi@dev":
+  version "0.16.1-dev-1539367749-ga71db160"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.1-dev-1539367749-ga71db160.tgz#b67f9e5f171e5498a675b0c902d14972020a96c7"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -59,18 +59,19 @@
     source-map-support "^0.4.16"
     ts-node "^7.0.0"
     typescript "^3.0.0"
+    upath "^1.1.0"
 
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
 
 "@types/node@^10.1.0":
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.0.tgz#ddd0d67a3b6c3810dd1a59e36675fa82de5e19ae"
+  version "10.11.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.7.tgz#0e75ca9357d646ca754016ca1d68a127ad7e7300"
 
 "@types/node@^8.0.26":
-  version "8.10.30"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.30.tgz#2c82cbed5f79d72280c131d2acffa88fbd8dd353"
+  version "8.10.36"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.36.tgz#eac05d576fbcd0b4ea3c912dc58c20475c08d9e4"
 
 "@types/semver@^5.4.0":
   version "5.5.0"
@@ -216,8 +217,8 @@ colour@~0.7.1:
   resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
 
 commander@^2.12.1:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -459,8 +460,8 @@ minipass@^2.2.1, minipass@^2.3.3:
     yallist "^3.0.0"
 
 minizlib@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.1.tgz#6734acc045a46e61d596a43bb9d9cd326e19cc42"
   dependencies:
     minipass "^2.2.1"
 
@@ -475,8 +476,8 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 nan@^2.0.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
 
 needle@^2.2.1:
   version "2.2.4"
@@ -522,8 +523,8 @@ npm-bundled@^1.0.1:
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
 
 npm-packlist@^1.1.6:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.11.tgz#84e8c683cbe7867d34b1d357d893ce29e28a02de"
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.12.tgz#22bde2ebc12e72ca482abd67afc51eb49377243a"
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -695,8 +696,8 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.0:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
 set-blocking@~2.0.0:
   version "2.0.0"
@@ -732,15 +733,15 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.2.tgz#19bb409e91b47b1ad54159243f7312a858db3c2e"
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
 
 spdx-exceptions@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
 
 spdx-expression-parse@^3.0.0:
   version "3.0.0"
@@ -780,7 +781,7 @@ string_decoder@~1.1.1:
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  resolved "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
 
@@ -857,8 +858,12 @@ tsutils@^2.27.2:
     tslib "^1.8.1"
 
 typescript@^3.0.0, typescript@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
+
+upath@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi/issues/2052

Normal docker spew is simply captured as ephemeral messages (so you can see what's going on), without reprinting it.  If, however, any errors do occur, then we will print out the messages.

Docker output now looks like:

![image](https://user-images.githubusercontent.com/4564579/46892230-95f67600-ce21-11e8-859b-d9ba3fa4c481.png)

During execution you see stuff like:

![image](https://user-images.githubusercontent.com/4564579/46892273-b0305400-ce21-11e8-878c-d67332409b47.png)
