### PR TITLE
Tag docker target images with a unique name

### DIFF
--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -134,7 +134,7 @@ function logEphemeral(message: string, logResource: pulumi.Resource) {
 // name, without pushing. During a normal update, it will do the same, as well as tag and push the
 // image.
 export async function buildAndPushImageAsync(
-    imageName: string,
+    baseImageName: string,
     pathOrBuild: string | DockerBuild,
     repositoryUrl: string,
     logResource: pulumi.Resource,
@@ -145,7 +145,7 @@ export async function buildAndPushImageAsync(
     logEphemeral("Starting docker build and push...", logResource);
 
     const result = await buildAndPushImageWorkerAsync(
-        imageName, pathOrBuild, repositoryUrl, logResource, connectToRegistry);
+        baseImageName, pathOrBuild, repositoryUrl, logResource, connectToRegistry);
 
     // If we got here, then building/pushing didn't throw any errors.  Update the status bar
     // indicating that things worked properly.  That way, the info bar isn't stuck showing the very
@@ -156,13 +156,13 @@ export async function buildAndPushImageAsync(
 }
 
 async function buildAndPushImageWorkerAsync(
-    unprocessedImageName: string,
+    baseImageName: string,
     pathOrBuild: string | DockerBuild,
     repositoryUrl: string,
     logResource: pulumi.Resource,
     connectToRegistry: (() => Promise<Registry>) | undefined): Promise<string> {
 
-    const { imageName, tag } = getImageNameAndTag(unprocessedImageName);
+    const { imageName, tag } = getImageNameAndTag(baseImageName);
 
     let loggedIn: Promise<void> | undefined;
 
@@ -223,10 +223,10 @@ function localStageImageName(imageName: string, stage: string) {
     return `${imageName}-${stage}`;
 }
 
-function getImageNameAndTag(unprocessedImageName: string): { imageName: string, tag: string | undefined } {
-    const lastColon = unprocessedImageName.lastIndexOf(":");
-    const imageName = lastColon < 0 ? unprocessedImageName : unprocessedImageName.substr(0, lastColon);
-    const tag = lastColon < 0 ? undefined : unprocessedImageName.substr(lastColon + 1);
+function getImageNameAndTag(baseImageName: string): { imageName: string, tag: string | undefined } {
+    const lastColon = baseImageName.lastIndexOf(":");
+    const imageName = lastColon < 0 ? baseImageName : baseImageName.substr(0, lastColon);
+    const tag = lastColon < 0 ? undefined : baseImageName.substr(lastColon + 1);
 
     return  { imageName, tag };
 }

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -249,11 +249,11 @@ function createTaggedImageName(repositoryUrl: string, tag: string | undefined, i
         pieces.push(imageId);
     }
 
-    // A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits,
-    // underscores, periods and dashes. A tag name may not start with a period or a dash and may
-    // contain a maximum of 128 characters.
-    const fullTag = pieces.join("-").replace(/[^-_.a-zA-Z0-9]/, "").substr(0, 128);
-
+    // Note: we don't do any validation that the tag is well formed, as per:
+    // https://docs.docker.com/engine/reference/commandline/tag
+    //
+    // If there are any issues with it, we'll just let docker report the problem.
+    const fullTag = pieces.join("-");
     return fullTag ? `${repositoryUrl}:${fullTag}` : repositoryUrl;
 }
 

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -223,6 +223,15 @@ function localStageImageName(imageName: string, stage: string) {
 }
 
 function getImageNameAndTag(baseImageName: string): { imageName: string, tag: string | undefined } {
+    // From https://docs.docker.com/engine/reference/commandline/tag
+    //
+    // "A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits,
+    // underscores, periods and dashes. A tag name may not start with a period or a dash and may
+    // contain a maximum of 128 characters."
+    //
+    // So it is safe for us to just look for the colon, and consume whatever follows as the tag
+    // for the image.
+
     const lastColon = baseImageName.lastIndexOf(":");
     const imageName = lastColon < 0 ? baseImageName : baseImageName.substr(0, lastColon);
     const tag = lastColon < 0 ? undefined : baseImageName.substr(lastColon + 1);

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -351,7 +351,13 @@ async function buildImageAsync(
            `No digest available for image ${imageName}`, logResource);
     }
 
-    // Trim off the hash kind if there is one.
+    // From https://docs.docker.com/registry/spec/api/#content-digests
+    //
+    // the image id will be a "algorithm:hex" pair.  We don't care about the algorithm part.  All we
+    // want is the unique portion we can use elsewhere.  Since we are also going to place this in an
+    // image tag, we also don't want the colon, as that's not legal there.  So simply grab the hex
+    // portion after the colon and return that.
+
     let imageId = inspectResult.trim();
     const colonIndex = imageId.lastIndexOf(":");
     imageId = colonIndex < 0 ? imageId : imageId.substr(colonIndex + 1);

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -326,7 +326,8 @@ async function buildImageAsync(
     const stages = [];
     if (build.cacheFrom && typeof build.cacheFrom !== "boolean" && build.cacheFrom.stages) {
         for (const stage of build.cacheFrom.stages) {
-            await dockerBuild(localStageImageName(imageName, stage), build, cacheFrom, logResource, stage);
+            await dockerBuild(
+                localStageImageName(imageName, stage), build, cacheFrom, logResource, stage);
             stages.push(stage);
         }
     }

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -198,7 +198,7 @@ async function buildAndPushImageWorkerAsync(
     // some external system, making it suitable for unique identification, even during preview.
     // This also means that if docker produces a new imageId, we'll get a new name here, ensuring that
     // resources (like docker.Image and cloud.Service) will be appropriately replaced.
-    const uniqueTargetName = createTargetName(repositoryUrl, tag, imageId);
+    const uniqueTaggedImageName = createTaggedImageName(repositoryUrl, tag, imageId);
 
     // Use those then push the image.  Then just return the unique target name. as the final result
     // for our caller to use.
@@ -215,7 +215,7 @@ async function buildAndPushImageWorkerAsync(
         }
     }
 
-    return uniqueTargetName;
+    return uniqueTaggedImageName;
 }
 
 function localStageImageName(imageName: string, stage: string) {
@@ -230,7 +230,7 @@ function getImageNameAndTag(baseImageName: string): { imageName: string, tag: st
     return  { imageName, tag };
 }
 
-function createTargetName(repositoryUrl: string, tag: string | undefined, imageId: string | undefined): string {
+function createTaggedImageName(repositoryUrl: string, tag: string | undefined, imageId: string | undefined): string {
     const pieces: string[] = [];
     if (tag) {
         pieces.push(tag);
@@ -429,7 +429,7 @@ async function tagAndPushImageAsync(
         logResource: pulumi.Resource): Promise<void> {
 
     // Ensure we have a unique target name for this image, and tag and push to that unique target.
-    await doTagAndPushAsync(createTargetName(repositoryUrl, tag, imageId));
+    await doTagAndPushAsync(createTaggedImageName(repositoryUrl, tag, imageId));
 
     if (tag) {
         // user provided a tag themselves (like "x/y:dev").  In this case, also tag and push

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -201,7 +201,7 @@ async function buildAndPushImageWorkerAsync(
     // this tag doesn't require actually pushing the image, nor does it require communicating with
     // some external system, making it suitable for unique identification, even during preview.
     // This also means that if docker produces a new imageId, we'll get a new name here, ensuring that
-    // resources will be appropriately replaced.
+    // resources (like docker.Image and cloud.Service) will be appropriately replaced.
     const uniqueTargetName = createTargetName(repositoryUrl, tag, imageId);
 
     // Use those then push the image.  Then just return the unique target name. as the final result

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -211,11 +211,11 @@ async function buildAndPushImageWorkerAsync(
         await login();
 
         // Push the final image first, then push the stage images to use for caching.
-        await tagAndPushImageAsync(imageName, tag, imageId, repositoryUrl, logResource);
+        await tagAndPushImageAsync(imageName, repositoryUrl, tag, imageId, logResource);
 
         for (const stage of stages) {
             await tagAndPushImageAsync(
-                localStageImageName(imageName, stage), tag, /*imageId:*/ undefined, repositoryUrl, logResource);
+                localStageImageName(imageName, stage), repositoryUrl, tag, /*imageId:*/ undefined, logResource);
         }
     }
 
@@ -426,8 +426,9 @@ function isLoggedIn(registry: Registry): boolean {
 }
 
 async function tagAndPushImageAsync(
-        imageName: string, tag: string | undefined, imageId: string | undefined,
-        repositoryUrl: string, logResource: pulumi.Resource): Promise<void> {
+        imageName: string, repositoryUrl: string,
+        tag: string | undefined, imageId: string | undefined,
+        logResource: pulumi.Resource): Promise<void> {
 
     // Ensure we have a unique target name for this image, and tag and push to that unique target.
     await doTagAndPushAsync(createTargetName(repositoryUrl, tag, imageId));

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -192,10 +192,6 @@ async function buildAndPushImageWorkerAsync(
     // First build the image.
     const { imageId, stages } = await buildImageAsync(imageName, pathOrBuild, logResource, cacheFrom);
 
-    if (!repositoryUrl) {
-        throw new ResourceError("Expected repository URL to be defined during push", logResource);
-    }
-
     // Generate a name that uniquely will identify this built image.  This is similar in purpose to
     // the name@digest form that can be normally be retrieved from a docker repository.  However,
     // this tag doesn't require actually pushing the image, nor does it require communicating with

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -281,7 +281,9 @@ async function pullCacheAsync(
         const image = `${repoUrl}${tag}`;
 
         // Try to pull the existing image if it exists.  This may fail if the image does not exist.
-        // That's fine, just move onto the next stage.
+        // That's fine, just move onto the next stage.  Also, pass along a flag saying that we
+        // should print that error as a warning instead.  We don't want the update to succeed but
+        // the user to then get a nasty "error:" message at the end.
         const { code } = await runCommandThatCanFail(
             "docker", ["pull", image], logResource,
             /*reportFullCommand:*/ true, /*reportErrorAsWarning:*/ true);

--- a/docker/image.ts
+++ b/docker/image.ts
@@ -80,6 +80,16 @@ export class Image extends pulumi.ComponentResource {
      */
     public registryServer: pulumi.Output<string | undefined>;
 
+    /**@deprecated This will have the same value as [imageName], but will be removed in the future. */
+    public id: pulumi.Output<string>;
+
+    /**
+     * @deprecated This will have the same value as [imageName], but will be removed in the future.
+     * It can be used to get a unique name for this specific image, but is not the actual repository
+     * digest value.
+     */
+    public digest: pulumi.Output<string | undefined>;
+
     constructor(name: string, args: ImageArgs, opts?: pulumi.ComponentResourceOptions) {
         super("docker:image:Image", name, argsWithoutRegistry(args), opts);
 
@@ -107,12 +117,16 @@ export class Image extends pulumi.ComponentResource {
         });
 
         this.imageName = imageData.apply(d => d.uniqueTargetName);
+        this.id = this.imageName;
+        this.digest = this.imageName;
         this.registryServer = imageData.apply(d => d.registryServer);
         this.baseImageName = pulumi.output(args.imageName);
 
         this.registerOutputs({
             baseImageName: this.baseImageName,
             imageName: this.imageName,
+            id: this.id,
+            digest: this.digest,
             registryServer: this.registryServer,
         });
     }

--- a/docker/image.ts
+++ b/docker/image.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
-import { buildAndPushImageAsync, DockerBuild, getDigest } from "./docker";
+import * as docker from "./docker";
 
 /**
  * Arguments for constructing an Image resource.
@@ -27,7 +27,7 @@ export interface ImageArgs {
     /**
      * The Docker build context, as a folder path or a detailed DockerBuild object.
      */
-    build: pulumi.Input<string | DockerBuild>;
+    build: pulumi.Input<string | docker.DockerBuild>;
     /**
      * The docker image name to build locally before tagging with imageName.
      */
@@ -67,22 +67,14 @@ export interface ImageRegistry {
  */
 export class Image extends pulumi.ComponentResource {
     /**
-     * The base image name that was built and pushed.  This does not include the digest annotation, so is not pinned to
-     * the specific build performed by this docker.Image.
+     * The base image name that was built and pushed.  This does not include the id annotation, so
+     * is not pinned to the specific build performed by this docker.Image.
      */
     public baseImageName: pulumi.Output<string>;
     /**
-     * The pinned image name, including digest annotation.
+     * The pinned image name, including unique id annotation.
      */
     public imageName: pulumi.Output<string>;
-    /**
-     * The built image Id.
-     */
-    public id: pulumi.Output<string>;
-    /**
-     * The pushed image digest.
-     */
-    public digest: pulumi.Output<string | undefined>;
     /**
      * The server the image is located at.
      */
@@ -97,11 +89,11 @@ export class Image extends pulumi.ComponentResource {
                 localImageName = imageArgs.imageName;
             }
             const registry = imageArgs.registry;
-            const id = await buildAndPushImageAsync(
+            const uniqueTargetName = await docker.buildAndPushImageAsync(
                 localImageName,
                 imageArgs.build,
                 imageArgs.imageName,
-                this,
+                /*logResource:*/ this,
                 registry && (async () => {
                     return {
                         registry: registry.server,
@@ -110,22 +102,17 @@ export class Image extends pulumi.ComponentResource {
                     };
                 }),
             );
-            const digest = await getDigest(imageArgs.imageName, this);
-            return { digest, id, registryServer: registry && registry.server };
+
+            return { uniqueTargetName, registryServer: registry && registry.server };
         });
 
-        this.id = imageData.apply(d => d.id);
-        this.digest = imageData.apply(d => d.digest);
+        this.imageName = imageData.apply(d => d.uniqueTargetName);
         this.registryServer = imageData.apply(d => d.registryServer);
         this.baseImageName = pulumi.output(args.imageName);
-        this.imageName =
-            pulumi
-            .all([args.imageName, this.digest])
-            .apply(([imageName, digest]) => `${imageName}@${digest}`);
+
         this.registerOutputs({
             baseImageName: this.baseImageName,
             imageName: this.imageName,
-            digest: this.digest,
             registryServer: this.registryServer,
         });
     }

--- a/docker/image.ts
+++ b/docker/image.ts
@@ -80,7 +80,7 @@ export class Image extends pulumi.ComponentResource {
      */
     public registryServer: pulumi.Output<string | undefined>;
 
-    /**@deprecated This will have the same value as [imageName], but will be removed in the future. */
+    /** @deprecated This will have the same value as [imageName], but will be removed in the future. */
     public id: pulumi.Output<string>;
 
     /**

--- a/docker/image.ts
+++ b/docker/image.ts
@@ -72,7 +72,7 @@ export class Image extends pulumi.ComponentResource {
      */
     public baseImageName: pulumi.Output<string>;
     /**
-     * The pinned image name, including unique id annotation.
+     * The unique pinned image name on the remote repository.
      */
     public imageName: pulumi.Output<string>;
     /**

--- a/docker/yarn.lock
+++ b/docker/yarn.lock
@@ -46,8 +46,8 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
 "@pulumi/pulumi@dev":
-  version "0.16.1-dev-1539622375-g730a929c"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.1-dev-1539622375-g730a929c.tgz#8b069fc000171cf7d5691732c5b279ad26462369"
+  version "0.16.1-dev-1539729422-g32640120"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.1-dev-1539729422-g32640120.tgz#4b5783bd7542e2bc27f541bfb5cde7cfe3f7f72d"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -66,8 +66,8 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
 
 "@types/node@^10.1.0":
-  version "10.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.7.tgz#0e75ca9357d646ca754016ca1d68a127ad7e7300"
+  version "10.12.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
 
 "@types/node@^8.0.26":
   version "8.10.36"


### PR DESCRIPTION
We now tag all our docker pushed builds with a tag equal to their image-id.  i.e. we'll end up tagging a build like so:

`<awsid>.dkr.ecr.<region>.amazonaws.com/image-name:<image-id>` or
`<awsid>.dkr.ecr.<region>.amazonaws.com/image-name:<user-tag>-<image-id>`

By adding teh image-id into the tag name, we then have a unique and stable name for the target build that can be known at preview time.  It also means that any time docker produces a new image id, we end up replacing the image.  This helps us avoid needing to hack things in at the cloud layer where we place hte image-id in the environment variable map in order to get pulumi to want to replace the cloud.Service resource.

As part of this change docker.buildAndPushImage now retursn that entire target name, instead of just returning the image-id like it used to before.