### PR TITLE
Ensure we do always login to a registry when issuing multiple login requests to the same one.

### DIFF
--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -403,7 +403,7 @@ async function dockerBuild(
 interface LoginResult {
     registryName: string;
     username: string;
-    loginCommand: Promise<void> | undefined;
+    loginCommand: Promise<void>;
 }
 
 // Keep track of registries and users that have been logged in.  If we've already logged into that
@@ -430,7 +430,7 @@ function loginToRegistry(registry: Registry, logResource: pulumi.Resource): Prom
         logEphemeral(`Reusing existing login for ${username}@${registryName}`, logResource);
     }
 
-    return loginResult.loginCommand!;
+    return loginResult.loginCommand;
 
     async function loginAsync() {
         const dockerPasswordStdin = await useDockerPasswordStdin(logResource);

--- a/docker/docker.ts
+++ b/docker/docker.ts
@@ -397,48 +397,54 @@ async function dockerBuild(
     }
 
     await runCommandThatMustSucceed("docker", buildArgs, logResource);
+
+}
+
+interface LoginResult {
+    registryName:string;
+    username: string;
+    loginCommand: Promise<void> | undefined;
 }
 
 // Keep track of registries and users that have been logged in.  If we've already logged into that
 // registry with that user, there's no need to do it again.
-const loggedInUsers: { registryName: string, username: string }[] = [];
+const loginResults: LoginResult[] = [];
 
 async function loginToRegistry(registry: Registry, logResource: pulumi.Resource): Promise<void> {
     const { registry: registryName, username, password } = registry;
 
-    if (isLoggedIn(registry)) {
-        logEphemeral(`Reusing existing login for ${username}@${registryName}`, logResource);
-        return;
-    }
-
-    loggedInUsers.push({ registryName, username });
-
-    const dockerPasswordStdin = await useDockerPasswordStdin(logResource);
-
-    // pass 'reportFullCommandLine: false' here so that if we fail to login we don't emit the
-    // username/password in our logs.  Instead, we'll just say "'docker login' failed with code ..."
-    if (dockerPasswordStdin) {
-        await runCommandThatMustSucceed(
-            "docker", ["login", "-u", username, "--password-stdin", registryName],
-            logResource, /*reportFullCommandLine*/ false, password);
+    // See if we've issued an outstanding requests to login into this registry.  If so, just
+    // await the results of that login request.  Otherwise, create a new request and keep it
+    // around so that future login requests will see it.
+    let loginResult = loginResults.find(
+        r => r.registryName === registryName && r.username === username);
+    if (!loginResult) {
+        loginResult = { registryName, username, loginCommand: loginAsync() };
+        loginResults.push(loginResult);
     }
     else {
-        await runCommandThatMustSucceed(
-            "docker", ["login", "-u", username, "-p", password, registryName],
-            logResource, /*reportFullCommandLine*/ false);
+        logEphemeral(`Reusing existing login for ${username}@${registryName}`, logResource);
     }
-}
 
-function isLoggedIn(registry: Registry): boolean {
-    for (const { registryName, username } of loggedInUsers) {
-        if (registryName === registry.registry &&
-            username === registry.username) {
+    await loginResult.loginCommand;
+    return;
 
-            return true;
+    async function loginAsync() {
+        const dockerPasswordStdin = await useDockerPasswordStdin(logResource);
+
+        // pass 'reportFullCommandLine: false' here so that if we fail to login we don't emit the
+        // username/password in our logs.  Instead, we'll just say "'docker login' failed with code ..."
+        if (dockerPasswordStdin) {
+            await runCommandThatMustSucceed(
+                "docker", ["login", "-u", username, "--password-stdin", registryName],
+                logResource, /*reportFullCommandLine*/ false, password);
+        }
+        else {
+            await runCommandThatMustSucceed(
+                "docker", ["login", "-u", username, "-p", password, registryName],
+                logResource, /*reportFullCommandLine*/ false);
         }
     }
-
-    return false;
 }
 
 async function tagAndPushImageAsync(


### PR DESCRIPTION
Fixes issue where we were incorrectly skipping logging into a docker registry when doing a parallel update with many resources coming from the same registry.  The problem stemmed from a previous PR where we tried to prevent logging into the same docker registry multiple times.  That change was buggy in that it recorded we were logged in prior to actually executing the login.  That meant that when one update was actually doing the login (asynchronously), another resource could then move forward, try to login, think it was logged in (even though the first hadn't completed) and then would continue on to further docker operations which would then fail. 

This change now makes it so that we store around the actual promise tracking the real login.  While that login is asynchonously computing, if any other login requests come along, they will then see and await that real login, meaning none of those registry operations make progress until the first login to that registry returns.