### PR TITLE
Depend on stable packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.16.3 (unreleased)
 
+### Improvements
+
+- Updated package constraints such that we do not depend on unreleased versions of `@pulumi/pulumi`.
+
 ## 0.16.2 (Released December 5th, 2018)
 
 ### Improvements

--- a/resources.go
+++ b/resources.go
@@ -112,7 +112,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
-				"@pulumi/pulumi": "dev",
+				"@pulumi/pulumi": "^0.16.4",
 				"semver":         "^5.4.0",
 			},
 			DevDependencies: map[string]string{
@@ -128,7 +128,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		Python: &tfbridge.PythonInfo{
 			Requires: map[string]string{
-				"pulumi": ">=0.16.4",
+				"pulumi": ">=0.16.4,<0.17.0",
 			},
 		},
 	}

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "dev",
+        "@pulumi/pulumi": "^0.16.4",
         "semver": "^5.4.0"
     },
     "devDependencies": {

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -29,6 +29,6 @@ setup(name='pulumi_docker',
       license='Apache-2.0',
       packages=find_packages(),
       install_requires=[
-          'pulumi>=0.16.4'
+          'pulumi>=0.16.4,<0.17.0'
       ],
       zip_safe=False)


### PR DESCRIPTION
We were depending on the "dev" tag of `@pulumi/pulumi`, instead of a
released version. In addition, I've tightened the python constraint
such that we don't roll forward to a 0.17.0 which may have breaking
changes.