### PR TITLE
Add ability to specify extra options for docker build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.17.2 (Unreleased)
 
+- Add ability to specify arbitrary extra `docker build` CLI options for `buildAndPush...()` functions.
+
 ## 0.17.1 (Released March 7, 2019)
 
 ## Improvements

--- a/sdk/nodejs/docker.ts
+++ b/sdk/nodejs/docker.ts
@@ -75,7 +75,7 @@ export interface DockerBuild {
      * An optional catch-all string to provide extra CLI options to the docker build command.  For
      * example, use to specify `--network host`.
      */
-    extraOptions?: pulumi.Input<string[]>;
+    extraOptions?: pulumi.Input<Input<string>[]>;
 }
 
 let dockerPasswordPromise: Promise<boolean> | undefined;

--- a/sdk/nodejs/docker.ts
+++ b/sdk/nodejs/docker.ts
@@ -75,7 +75,7 @@ export interface DockerBuild {
      * An optional catch-all string to provide extra CLI options to the docker build command.  For
      * example, use to specify `--network host`.
      */
-    extraOptions?: pulumi.Input<Input<string>[]>;
+    extraOptions?: pulumi.Input<pulumi.Input<string>[]>;
 }
 
 let dockerPasswordPromise: Promise<boolean> | undefined;

--- a/sdk/nodejs/docker.ts
+++ b/sdk/nodejs/docker.ts
@@ -70,6 +70,12 @@ export interface DockerBuild {
      * a CacheFrom object, the stages named therein will also be pulled and passed to --cache-from.
      */
     cacheFrom?: pulumi.Input<boolean | CacheFrom>;
+
+    /**
+     * An optional catch-all string to provide extra CLI options to the docker build command.  For
+     * example, use to specify `--network host`.
+     */
+    extraOptions?: pulumi.Input<string[]>;
 }
 
 let dockerPasswordPromise: Promise<boolean> | undefined;
@@ -402,6 +408,9 @@ async function dockerBuild(
         if (cacheFromImages && cacheFromImages.length) {
             buildArgs.push(...[ "--cache-from", cacheFromImages.join() ]);
         }
+    }
+    if (build.extraOptions) {
+        buildArgs.push(...build.extraOptions);
     }
     buildArgs.push(build.context!); // push the docker build context onto the path.
 


### PR DESCRIPTION
Add the ability to specify extra `docker build` CLI options that can be provided to `buildAndPushImage()`.

Allows you to specify things like `--network host` or others, without having to semantically enumerate every option of the docker `CLI` in this interface.