### PR TITLE
prevent tags from being stripped for the build image names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 0.17.3 (Unreleased)
 
+- Fix image tag name collission during build time (https://github.com/pulumi/pulumi-docker/pull/90)
+
 ## 0.17.2 (Released July 19, 2019)
 
 - Add ability to specify arbitrary extra `docker build` CLI options for `buildAndPush...()` functions.
-- Fix image tag name collission during build time (https://github.com/pulumi/pulumi-docker/pull/90)
 
 ## 0.17.1 (Released March 7, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.17.2 (Unreleased)
 
 - Add ability to specify arbitrary extra `docker build` CLI options for `buildAndPush...()` functions.
+- Fix image tag name collission during build time (https://github.com/pulumi/pulumi-docker/pull/90)
 
 ## 0.17.1 (Released March 7, 2019)
 


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi-docker/issues/56

Not specifying a tag when building an image makes it use `latest`, this causes Pulumi to overwrite the first image build when deploying multiple images that use the same repository but different tags.