### PR TITLE
Frontload logging into the registry before we do any actual docker calls

### DIFF
--- a/sdk/nodejs/docker.ts
+++ b/sdk/nodejs/docker.ts
@@ -192,7 +192,7 @@ async function buildAndPushImageWorkerAsync(
         // logged-in to the correct registry (or uses auto-login via credential helpers).
         if (connectToRegistry) {
             logEphemeral("Logging in to registry...", logResource);
-            const registryOutput = pulumi.output(connectToRegistry!());
+            const registryOutput = pulumi.output(connectToRegistry());
             const registryPromise: Promise<pulumi.Unwrap<Registry>> = (<any>registryOutput).promise();
             const registry = await registryPromise;
             await loginToRegistry(registry, logResource);

--- a/sdk/nodejs/docker.ts
+++ b/sdk/nodejs/docker.ts
@@ -205,7 +205,8 @@ async function buildAndPushImageWorkerAsync(
         // NOTE: we pull the promise out of the repository URL s.t. we can observe whether or not it
         // exists. Were we to instead hang an apply off of the raw Input<>, we would never end up
         // running the pull if the repository had not yet been created.
-        const cacheFromParam = typeof pathOrBuild.cacheFrom === "boolean" ? {} : pathOrBuild.cacheFrom;
+        const dockerBuild = <pulumi.UnwrappedObject<DockerBuild>>pathOrBuild;
+        const cacheFromParam = typeof dockerBuild.cacheFrom === "boolean" ? {} : dockerBuild.cacheFrom;
         cacheFrom = pullCacheAsync(imageName, cacheFromParam, repositoryUrl, logResource);
     }
 


### PR DESCRIPTION
This is an experiment to see if we can workaround the async-invoke problem downstream by ensuring that we make all docker calls *after* our call to get the registry info.