### PR TITLE
Allow a user to pass a build target to image.Image in nodejs SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Upgrade to v2.6.0 of the Docker Terraform Provider
 * Upgrade to go1.13
 * Add support for .NET (https://github.com/pulumi/pulumi-docker/pull/115)
+* Allow users to pass `target` in image.Image when using multi-target Dockerfiles
 
 ## 0.17.4 (Released September 5, 2019)
 

--- a/examples/dockerfile-with-targets/.gitignore
+++ b/examples/dockerfile-with-targets/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/examples/dockerfile-with-targets/Dockerfile
+++ b/examples/dockerfile-with-targets/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.6 AS base
+
+FROM base AS dependencies
+RUN pip install gunicorn

--- a/examples/dockerfile-with-targets/Pulumi.yaml
+++ b/examples/dockerfile-with-targets/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: dockerfile-with-multiple-targets
+runtime: nodejs
+description: A pulumi application that has a dockerfile with multiple targets

--- a/examples/dockerfile-with-targets/index.ts
+++ b/examples/dockerfile-with-targets/index.ts
@@ -1,0 +1,11 @@
+import * as docker from "@pulumi/docker";
+
+const myDependenciesImage = new docker.Image("my-image", {
+    imageName: "pulumi-user/example:v1.0.0",
+    build: {
+        target: "dependencies",
+    },
+    skipPush: true,
+});
+
+export const depsImage = myDependenciesImage.imageName;

--- a/examples/dockerfile-with-targets/package.json
+++ b/examples/dockerfile-with-targets/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "dockerfile-with-targets",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "dev"
+    },
+    "peerDependencies": {
+        "@pulumi/docker": "dev"
+    }
+}

--- a/examples/dockerfile-with-targets/tsconfig.json
+++ b/examples/dockerfile-with-targets/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -110,3 +110,18 @@ func TestDotNet(t *testing.T) {
 	})
 	integration.ProgramTest(t, &opts)
 }
+
+func TestDockerfileWithMultipleTargets(t *testing.T) {
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	opts := base.With(integration.ProgramTestOptions{
+		Dependencies: []string{
+			"@pulumi/docker",
+		},
+		Dir: path.Join(cwd, "dockerfile-with-targets"),
+	})
+	integration.ProgramTest(t, &opts)
+}

--- a/sdk/nodejs/docker.ts
+++ b/sdk/nodejs/docker.ts
@@ -84,6 +84,11 @@ export interface DockerBuild {
      * `DOCKER_BUILDKIT=1 docker build`.
      */
     env?: Record<string, string>;
+
+    /***
+     * The target of the dockerfile to build
+     */
+    target?: pulumi.Input<string>;
 }
 
 let dockerPasswordPromise: Promise<boolean> | undefined;
@@ -389,7 +394,8 @@ async function buildImageAsync(
     logEphemeral(
         `Building container image '${imageName}': context=${build.context}` +
         (build.dockerfile ? `, dockerfile=${build.dockerfile}` : "") +
-        (build.args ? `, args=${JSON.stringify(build.args)}` : ""), logResource);
+        (build.args ? `, args=${JSON.stringify(build.args)}` : "") +
+        (build.target ? `, target=${build.target}` : ""), logResource);
 
     // If the container build specified build stages to cache, build each in turn.
     const stages = [];
@@ -443,6 +449,9 @@ async function dockerBuild(
         for (const arg of Object.keys(build.args)) {
             buildArgs.push(...["--build-arg", `${arg}=${build.args[arg]}`]);
         }
+    }
+    if (build.target) {
+        buildArgs.push(...["--target", build.target]);
     }
     if (build.cacheFrom) {
         const cacheFromImages = await cacheFrom;


### PR DESCRIPTION
Fixes: #37

This allows a user to use a multi-target Dockerfile