### PR TITLE
Changing the Name of the docker Config resource to be ServiceConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (Unreleased)
 * Upgrade to v2.7.0 of the Docker Terraform Provider
+* Rename `docker.Config` to `docker.ServiceConfig` to avoid collisions with `Config` package.
 
 ## 1.2.0 (2020-01-29)
 * Upgrade to pulumi-terraform-bridge v1.6.4

--- a/resources.go
+++ b/resources.go
@@ -98,8 +98,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"docker_config": {
-				Tok: dockerResource(dockerMod, "Config"),
-				CSharpName: "ServiceConfig",
+				Tok: dockerResource(dockerMod, "ServiceConfig"),
 			},
 			"docker_container": {
 				Tok:                 dockerResource(dockerMod, "Container"),

--- a/sdk/dotnet/ServiceConfig.cs
+++ b/sdk/dotnet/ServiceConfig.cs
@@ -36,12 +36,12 @@ namespace Pulumi.Docker
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
         public ServiceConfig(string name, ServiceConfigArgs args, CustomResourceOptions? options = null)
-            : base("docker:index/config:Config", name, args ?? ResourceArgs.Empty, MakeResourceOptions(options, ""))
+            : base("docker:index/serviceConfig:ServiceConfig", name, args ?? ResourceArgs.Empty, MakeResourceOptions(options, ""))
         {
         }
 
         private ServiceConfig(string name, Input<string> id, ServiceConfigState? state = null, CustomResourceOptions? options = null)
-            : base("docker:index/config:Config", name, state, MakeResourceOptions(options, id))
+            : base("docker:index/serviceConfig:ServiceConfig", name, state, MakeResourceOptions(options, id))
         {
         }
 

--- a/sdk/go/docker/serviceConfig.go
+++ b/sdk/go/docker/serviceConfig.go
@@ -14,7 +14,7 @@ import (
 // Manages the configuration of a Docker service in a swarm.
 // 
 // > This content is derived from https://github.com/terraform-providers/terraform-provider-docker/blob/master/website/docs/r/config.html.markdown.
-type Config struct {
+type ServiceConfig struct {
 	pulumi.CustomResourceState
 
 	// The base64 encoded data of the config.
@@ -23,70 +23,70 @@ type Config struct {
 	Name pulumi.StringOutput `pulumi:"name"`
 }
 
-// NewConfig registers a new resource with the given unique name, arguments, and options.
-func NewConfig(ctx *pulumi.Context,
-	name string, args *ConfigArgs, opts ...pulumi.ResourceOption) (*Config, error) {
+// NewServiceConfig registers a new resource with the given unique name, arguments, and options.
+func NewServiceConfig(ctx *pulumi.Context,
+	name string, args *ServiceConfigArgs, opts ...pulumi.ResourceOption) (*ServiceConfig, error) {
 	if args == nil || args.Data == nil {
 		return nil, errors.New("missing required argument 'Data'")
 	}
 	if args == nil {
-		args = &ConfigArgs{}
+		args = &ServiceConfigArgs{}
 	}
-	var resource Config
-	err := ctx.RegisterResource("docker:index/config:Config", name, args, &resource, opts...)
+	var resource ServiceConfig
+	err := ctx.RegisterResource("docker:index/serviceConfig:ServiceConfig", name, args, &resource, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return &resource, nil
 }
 
-// GetConfig gets an existing Config resource's state with the given name, ID, and optional
+// GetServiceConfig gets an existing ServiceConfig resource's state with the given name, ID, and optional
 // state properties that are used to uniquely qualify the lookup (nil if not required).
-func GetConfig(ctx *pulumi.Context,
-	name string, id pulumi.IDInput, state *ConfigState, opts ...pulumi.ResourceOption) (*Config, error) {
-	var resource Config
-	err := ctx.ReadResource("docker:index/config:Config", name, id, state, &resource, opts...)
+func GetServiceConfig(ctx *pulumi.Context,
+	name string, id pulumi.IDInput, state *ServiceConfigState, opts ...pulumi.ResourceOption) (*ServiceConfig, error) {
+	var resource ServiceConfig
+	err := ctx.ReadResource("docker:index/serviceConfig:ServiceConfig", name, id, state, &resource, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return &resource, nil
 }
 
-// Input properties used for looking up and filtering Config resources.
-type configState struct {
+// Input properties used for looking up and filtering ServiceConfig resources.
+type serviceConfigState struct {
 	// The base64 encoded data of the config.
 	Data *string `pulumi:"data"`
 	// The name of the Docker config.
 	Name *string `pulumi:"name"`
 }
 
-type ConfigState struct {
+type ServiceConfigState struct {
 	// The base64 encoded data of the config.
 	Data pulumi.StringPtrInput
 	// The name of the Docker config.
 	Name pulumi.StringPtrInput
 }
 
-func (ConfigState) ElementType() reflect.Type {
-	return reflect.TypeOf((*configState)(nil)).Elem()
+func (ServiceConfigState) ElementType() reflect.Type {
+	return reflect.TypeOf((*serviceConfigState)(nil)).Elem()
 }
 
-type configArgs struct {
+type serviceConfigArgs struct {
 	// The base64 encoded data of the config.
 	Data string `pulumi:"data"`
 	// The name of the Docker config.
 	Name *string `pulumi:"name"`
 }
 
-// The set of arguments for constructing a Config resource.
-type ConfigArgs struct {
+// The set of arguments for constructing a ServiceConfig resource.
+type ServiceConfigArgs struct {
 	// The base64 encoded data of the config.
 	Data pulumi.StringInput
 	// The name of the Docker config.
 	Name pulumi.StringPtrInput
 }
 
-func (ConfigArgs) ElementType() reflect.Type {
-	return reflect.TypeOf((*configArgs)(nil)).Elem()
+func (ServiceConfigArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*serviceConfigArgs)(nil)).Elem()
 }
 

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -2,7 +2,6 @@
 // *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 // Export members:
-export * from "./config";
 export * from "./container";
 export * from "./docker";
 export * from "./getNetwork";
@@ -13,6 +12,7 @@ export * from "./provider";
 export * from "./remoteImage";
 export * from "./secret";
 export * from "./service";
+export * from "./serviceConfig";
 export * from "./volume";
 
 // Export sub-modules:

--- a/sdk/nodejs/serviceConfig.ts
+++ b/sdk/nodejs/serviceConfig.ts
@@ -14,38 +14,38 @@ import * as utilities from "./utilities";
  * import * as docker from "@pulumi/docker";
  * 
  * // Creates a config
- * const fooConfig = new docker.Config("fooConfig", {
+ * const fooConfig = new docker.ServiceConfig("fooConfig", {
  *     data: "ewogICJzZXJIfQo=",
  * });
  * ```
  *
  * > This content is derived from https://github.com/terraform-providers/terraform-provider-docker/blob/master/website/docs/r/config.html.markdown.
  */
-export class Config extends pulumi.CustomResource {
+export class ServiceConfig extends pulumi.CustomResource {
     /**
-     * Get an existing Config resource's state with the given name, ID, and optional extra
+     * Get an existing ServiceConfig resource's state with the given name, ID, and optional extra
      * properties used to qualify the lookup.
      *
      * @param name The _unique_ name of the resulting resource.
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ConfigState, opts?: pulumi.CustomResourceOptions): Config {
-        return new Config(name, <any>state, { ...opts, id: id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ServiceConfigState, opts?: pulumi.CustomResourceOptions): ServiceConfig {
+        return new ServiceConfig(name, <any>state, { ...opts, id: id });
     }
 
     /** @internal */
-    public static readonly __pulumiType = 'docker:index/config:Config';
+    public static readonly __pulumiType = 'docker:index/serviceConfig:ServiceConfig';
 
     /**
-     * Returns true if the given object is an instance of Config.  This is designed to work even
+     * Returns true if the given object is an instance of ServiceConfig.  This is designed to work even
      * when multiple copies of the Pulumi SDK have been loaded into the same process.
      */
-    public static isInstance(obj: any): obj is Config {
+    public static isInstance(obj: any): obj is ServiceConfig {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Config.__pulumiType;
+        return obj['__pulumiType'] === ServiceConfig.__pulumiType;
     }
 
     /**
@@ -58,21 +58,21 @@ export class Config extends pulumi.CustomResource {
     public readonly name!: pulumi.Output<string>;
 
     /**
-     * Create a Config resource with the given unique name, arguments, and options.
+     * Create a ServiceConfig resource with the given unique name, arguments, and options.
      *
      * @param name The _unique_ name of the resource.
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: ConfigArgs, opts?: pulumi.CustomResourceOptions)
-    constructor(name: string, argsOrState?: ConfigArgs | ConfigState, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args: ServiceConfigArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, argsOrState?: ServiceConfigArgs | ServiceConfigState, opts?: pulumi.CustomResourceOptions) {
         let inputs: pulumi.Inputs = {};
         if (opts && opts.id) {
-            const state = argsOrState as ConfigState | undefined;
+            const state = argsOrState as ServiceConfigState | undefined;
             inputs["data"] = state ? state.data : undefined;
             inputs["name"] = state ? state.name : undefined;
         } else {
-            const args = argsOrState as ConfigArgs | undefined;
+            const args = argsOrState as ServiceConfigArgs | undefined;
             if (!args || args.data === undefined) {
                 throw new Error("Missing required property 'data'");
             }
@@ -86,14 +86,14 @@ export class Config extends pulumi.CustomResource {
         if (!opts.version) {
             opts.version = utilities.getVersion();
         }
-        super(Config.__pulumiType, name, inputs, opts);
+        super(ServiceConfig.__pulumiType, name, inputs, opts);
     }
 }
 
 /**
- * Input properties used for looking up and filtering Config resources.
+ * Input properties used for looking up and filtering ServiceConfig resources.
  */
-export interface ConfigState {
+export interface ServiceConfigState {
     /**
      * The base64 encoded data of the config.
      */
@@ -105,9 +105,9 @@ export interface ConfigState {
 }
 
 /**
- * The set of arguments for constructing a Config resource.
+ * The set of arguments for constructing a ServiceConfig resource.
  */
-export interface ConfigArgs {
+export interface ServiceConfigArgs {
     /**
      * The base64 encoded data of the config.
      */

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -13,7 +13,6 @@
         "strict": true
     },
     "files": [
-        "config.ts",
         "config/index.ts",
         "config/vars.ts",
         "container.ts",
@@ -27,6 +26,7 @@
         "remoteImage.ts",
         "secret.ts",
         "service.ts",
+        "serviceConfig.ts",
         "types/index.ts",
         "types/input.ts",
         "types/output.ts",

--- a/sdk/python/pulumi_docker/__init__.py
+++ b/sdk/python/pulumi_docker/__init__.py
@@ -10,7 +10,7 @@ for pkg in __all__:
         importlib.import_module(f'{__name__}.{pkg}')
 
 # Export this package's modules as members:
-from .config import *
+from .service_config import *
 from .container import *
 from .remote_image import *
 from .network import *

--- a/sdk/python/pulumi_docker/service_config.py
+++ b/sdk/python/pulumi_docker/service_config.py
@@ -9,7 +9,7 @@ import pulumi.runtime
 from typing import Union
 from . import utilities, tables
 
-class Config(pulumi.CustomResource):
+class ServiceConfig(pulumi.CustomResource):
     data: pulumi.Output[str]
     """
     The base64 encoded data of the config.
@@ -50,8 +50,8 @@ class Config(pulumi.CustomResource):
                 raise TypeError("Missing required property 'data'")
             __props__['data'] = data
             __props__['name'] = name
-        super(Config, __self__).__init__(
-            'docker:index/config:Config',
+        super(ServiceConfig, __self__).__init__(
+            'docker:index/serviceConfig:ServiceConfig',
             resource_name,
             __props__,
             opts)
@@ -59,7 +59,7 @@ class Config(pulumi.CustomResource):
     @staticmethod
     def get(resource_name, id, opts=None, data=None, name=None):
         """
-        Get an existing Config resource's state with the given name, id, and optional extra
+        Get an existing ServiceConfig resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
         
         :param str resource_name: The unique name of the resulting resource.
@@ -75,7 +75,7 @@ class Config(pulumi.CustomResource):
         __props__ = dict()
         __props__["data"] = data
         __props__["name"] = name
-        return Config(resource_name, opts=opts, __props__=__props__)
+        return ServiceConfig(resource_name, opts=opts, __props__=__props__)
     def translate_output_property(self, prop):
         return tables._CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
 


### PR DESCRIPTION
Fixes: #140

We had `docker_config` being created as `Config` in the NodeJS, Go
and Python packages. This was actually colliding with the `Config`
module of each of the packages but was particularly breaking the
Python integration. We are going to accept that this is technically
a breaking change BUT that it's for the better since it actually
makes the Config module usable

The DotNet SDK was already using `ServiceConfig` so we made the
other SDKs similar to this