### PR TITLE
Add remote image test for Go

### DIFF
--- a/examples/nginx-go/Gopkg.toml
+++ b/examples/nginx-go/Gopkg.toml
@@ -1,0 +1,38 @@
+# Gopkg.toml example
+#
+# Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
+# for detailed Gopkg.toml documentation.
+#
+# required = ["github.com/user/thing/cmd/thing"]
+# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
+#
+# [[constraint]]
+#   name = "github.com/user/project"
+#   version = "1.0.0"
+#
+# [[constraint]]
+#   name = "github.com/user/project2"
+#   branch = "dev"
+#   source = "github.com/myfork/project2"
+#
+# [[override]]
+#   name = "github.com/x/y"
+#   version = "2.4.0"
+#
+# [prune]
+#   non-go = false
+#   go-tests = true
+#   unused-packages = true
+
+
+[[constraint]]
+  name = "github.com/pulumi/pulumi"
+  version = "1.9.1"
+
+[[constraint]]
+  name = "github.com/pulumi/pulumi-docker"
+  version = "1.2.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/examples/nginx-go/Pulumi.yaml
+++ b/examples/nginx-go/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: nginx-go
+runtime: go
+description: A minimal Go Pulumi program
+template:
+  description: A minimal Go Pulumi program

--- a/examples/nginx-go/main.go
+++ b/examples/nginx-go/main.go
@@ -19,12 +19,12 @@ func main() {
 		}
 
 		// Launch a container using the nginx image we just downloaded.
-		port := docker.ContainerPortArgs{
+		portArgs := docker.ContainerPortArgs{
 			Internal: pulumi.Int(80),
 		}
 		containerArgs := &docker.ContainerArgs{
 			Image: image.Latest,
-			Ports: docker.ContainerPortArray([]docker.ContainerPortInput{port}),
+			Ports: docker.ContainerPortArray([]docker.ContainerPortInput{portArgs}),
 		}
 		container, err := docker.NewContainer(ctx, "nginx", containerArgs)
 		if err != nil {
@@ -35,7 +35,9 @@ func main() {
 		ctx.Export("name", container.Name)
 
 		// Since the provider picked a random ephemeral port for this container, export the port.
-		ctx.Export("port", container.Ports.Index(pulumi.Int(0)))
+		port := container.Ports.Index(pulumi.Int(0))
+		ctx.Export("port", port)
+		ctx.Export("endpoint", pulumi.Sprintf("%s:%d", port.Ip().Elem(), port.External().Elem()))
 
 		return nil
 	})

--- a/examples/nginx-go/main.go
+++ b/examples/nginx-go/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-docker/sdk/go/docker"
+	"github.com/pulumi/pulumi/sdk/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Get a reference to the remote image "nginx:1.15.6". Without specifying the repository, the Docker provider will
+		// try to download it from the public Docker Hub.
+		imageArgs := &docker.RemoteImageArgs{
+			Name:        pulumi.String("nginx"),
+			KeepLocally: pulumi.Bool(true),
+		}
+		image, err := docker.NewRemoteImage(ctx, "nginx-image", imageArgs)
+		if err != nil {
+			return err
+		}
+
+		// Launch a container using the nginx image we just downloaded.
+		port := docker.ContainerPortArgs{
+			Internal: pulumi.Int(80),
+		}
+		containerArgs := &docker.ContainerArgs{
+			Image: image.Latest,
+			Ports: docker.ContainerPortArray([]docker.ContainerPortInput{port}),
+		}
+		container, err := docker.NewContainer(ctx, "nginx", containerArgs)
+		if err != nil {
+			return err
+		}
+
+		// Since the container is auto-named, export the name.
+		ctx.Export("name", container.Name)
+
+		// Since the provider picked a random ephemeral port for this container, export the port.
+		ctx.Export("port", container.Ports.Index(pulumi.Int(0)))
+
+		return nil
+	})
+}


### PR DESCRIPTION
This is the first step towards #128 and basically just the Go implementation of the existing `nginx` tests.