### PR TITLE
Use pulumi-ci AWS profile.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ before_install:
 install:
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
     - source ${PULUMI_SCRIPTS}/ci/configure-aws.sh
+    # Use the pulumi-ci AWS profile configured by the above script.
+    # This repo runs tests that require access to create resources in AWS.
+    - export AWS_PROFILE=pulumi-ci
     - curl -L https://get.pulumi.com/ | bash
     - export PATH=$HOME/.pulumi/bin:$PATH
 before_script:


### PR DESCRIPTION
Related to pulumi/home#845.

The `master` branch build failed during the integration test phase due to the AWS creds that were changed with https://github.com/pulumi/pulumi-docker/pull/171 having insufficient access to create AWS resources. This PR updates the Travis config file to use the right AWS profile. But that's only one part of it. The other part is that I will update the AWS creds in the Travis settings for this repo to use the creds that would allow it to use that profile.