### PR TITLE
Ensure the docker ImageName is formed correctly in Go SDK

### DIFF
--- a/sdk/go/docker/image.go
+++ b/sdk/go/docker/image.go
@@ -74,9 +74,9 @@ func NewImage(ctx *pulumi.Context,
 		// name appropriately if we were given a tag.
 		var baseImageName string
 		if tag != "" {
-			baseImageName = localImageName
-		} else {
 			baseImageName = fmt.Sprintf("%s:%s", localImageNameWithoutTag, tag)
+		} else {
+			baseImageName = localImageName
 		}
 
 		return buildAndPushImage(ctx, baseImageName, &imageArgs.Build,


### PR DESCRIPTION
Fixes: #183

The logic wasn't correct here - we were appending the tag when there
was no tag