### PR TITLE
consistently handle environment variables

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,6 +17,7 @@ env:
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TRAVIS_OS_NAME: linux
+  PULUMI_GO_DEP_ROOT: /home/runner/work/pulumi-docker
 jobs:
   build_sdk:
     name: build_sdk

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,6 +17,7 @@ env:
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TRAVIS_OS_NAME: linux
+  PULUMI_GO_DEP_ROOT: /home/runner/work/pulumi-docker
 jobs:
   build_sdk:
     name: build_sdk

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,6 +17,7 @@ env:
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TRAVIS_OS_NAME: linux
+  PULUMI_GO_DEP_ROOT: /home/runner/work/pulumi-docker
 jobs:
   build_sdk:
     name: build_sdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TRAVIS_OS_NAME: linux
+  PULUMI_GO_DEP_ROOT: /home/runner/work/pulumi-docker
 jobs:
   build_sdk:
     name: build_sdk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (Unreleased)
-_(none)_
+
+* Always append specified environment variables to the current OS environment variable set [#212](https://github.com/pulumi/pulumi-docker/pull/212)
 
 ---
 

--- a/examples/dockerfile-go/main.go
+++ b/examples/dockerfile-go/main.go
@@ -11,6 +11,9 @@ func main() {
 			ImageName: pulumi.String("pulumi-user/example:v1.0.0"),
 			Build: docker.DockerBuildArgs{
 				Target: pulumi.String("dependencies"),
+				Env: pulumi.StringMap{
+					"TEST_ENV": pulumi.String("42"),
+				},
 			},
 			SkipPush: pulumi.Bool(true),
 		}

--- a/examples/dockerfile-py/__main__.py
+++ b/examples/dockerfile-py/__main__.py
@@ -6,6 +6,7 @@ image = Image(
     image_name="pulumi-user/example:v1.0.0",
     build=DockerBuild(
         target="dependencies",
+        env={'TEST_ENV': '42'},
     ),
     skip_push=True,
 )

--- a/examples/dockerfile-with-targets/index.ts
+++ b/examples/dockerfile-with-targets/index.ts
@@ -4,6 +4,7 @@ const myDependenciesImage = new docker.Image("my-image", {
     imageName: "pulumi-user/example:v1.0.0",
     build: {
         target: "dependencies",
+        env: { "TEST_ENV": "42" },
     },
     skipPush: true,
 });

--- a/examples/dotnet/Program.cs
+++ b/examples/dotnet/Program.cs
@@ -14,6 +14,10 @@ class Program
                 ImageName = "pulumi-user/example:v1.0.0",
                 Build = new DockerBuild
                 {
+                    Env = new Dictionary<string, string>
+                    { 
+                        {"TEST_ENV", "42"}, 
+                    },
                     Target = "dependencies",
                 },
                 SkipPush = true,

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -32,7 +32,7 @@ func TestNginxGo(t *testing.T) {
 
 	opts := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
-			"github.com/pulumi/pulumi-docker/sdk/v2/go",
+			"github.com/pulumi/pulumi-docker/sdk/v2",
 		},
 		Dir: path.Join(cwd, "nginx-go"),
 	})
@@ -47,7 +47,7 @@ func TestDockerfileGo(t *testing.T) {
 
 	opts := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
-			"github.com/pulumi/pulumi-docker/sdk/v2/go",
+			"github.com/pulumi/pulumi-docker/sdk/v2",
 		},
 		Dir: path.Join(cwd, "dockerfile-go"),
 	})

--- a/sdk/go/docker/customTypes.go
+++ b/sdk/go/docker/customTypes.go
@@ -82,7 +82,7 @@ type DockerBuildArgs struct {
 	// An optional map of named build-time argument variables to set during the Docker build.
 	// This flag allows you to pass built-time variables that can be accessed like environment variables
 	// inside the `RUN` instruction.
-	Args pulumi.MapInput `pulumi:"args"`
+	Args pulumi.StringMap `pulumi:"args"`
 
 	// An optional CacheFrom object with information about the build stages to use for the Docker
 	// build cache.  This parameter maps to the --cache-from argument to the Docker CLI. If this
@@ -96,7 +96,7 @@ type DockerBuildArgs struct {
 
 	// Environment variables to set on the invocation of `docker build`, for example to support
 	// `DOCKER_BUILDKIT=1 docker build`.
-	Env pulumi.MapInput `pulumi:"env"`
+	Env pulumi.StringMapInput `pulumi:"env"`
 
 	// The target of the dockerfile to build.
 	Target pulumi.StringInput `pulumi:"target"`

--- a/sdk/nodejs/docker.ts
+++ b/sdk/nodejs/docker.ts
@@ -629,6 +629,8 @@ async function runCommandThatCanFail(
     const streamID = Math.floor(Math.random() * (1 << 30));
 
     return new Promise<CommandResult>((resolve, reject) => {
+        const osEnv = Object.assign({}, process.env);
+        env = Object.assign(osEnv, env)
         const p = child_process.spawn(cmd, args, {env});
 
         // We store the results from stdout in memory and will return them as a string.

--- a/sdk/python/pulumi_docker/docker.py
+++ b/sdk/python/pulumi_docker/docker.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import json
 import math
+import os
 import re
 import subprocess
 from random import random
@@ -638,6 +639,9 @@ def run_command_that_can_fail(
     stream_id = math.floor(random() * (1 << 30))
 
     cmd = [cmd_name] + args
+
+    if env is not None:
+        env = os.environ.copy().update(env)
 
     process = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE, stdin=subprocess.PIPE, encoding="utf-8")


### PR DESCRIPTION
This change makes sure that any environment variables passed in are appended to the current OS env vars. Adds tests to document behavior across languages.

Fixes https://github.com/pulumi/pulumi-docker/issues/196

Note: there is a breaking change for go types for Args and Env, but this is in the category of "never worked in the first place". The unmarshalling fails when you specify environment variables as is, so this change to types just makes it work as intended. 