### PR TITLE
Fix a race condition of not getting all the output in .NET Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Fix Python type hints for lists [#225](https://github.com/pulumi/pulumi-docker/pull/225)
 * Upgrade to pulumi-terraform-bridge v2.8.0
 * Upgrade to Pulumi v2.10.0
+* Fix .NET concurrency issue leading to "No digest available for image" while building an image
+  [#229](https://github.com/pulumi/pulumi-docker/pull/229)
 
 ---
 

--- a/sdk/dotnet/Docker.cs
+++ b/sdk/dotnet/Docker.cs
@@ -689,7 +689,11 @@ namespace Pulumi.Docker
 
             return;
 
-            void ProcessExited(object? sender, EventArgs e) => tcs.TrySetResult(true);
+            void ProcessExited(object? sender, EventArgs e)
+            {
+                process.WaitForExit();
+                tcs.TrySetResult(true);
+            }
         }
     }
 }

--- a/sdk/dotnet/Docker.cs
+++ b/sdk/dotnet/Docker.cs
@@ -621,17 +621,7 @@ namespace Pulumi.Docker
 
             try
             {
-                process.Start();
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
-
-                if (stdin != null)
-                {
-                    process.StandardInput.Write(stdin);
-                    process.StandardInput.Close();
-                }
-
-                await WaitForExitAsync(process);
+                await StartAndWaitForExitAsync(process, stdin);
                 var code = process.ExitCode;
 
                 // If we got any stderr messages, report them as an error/warning depending on the
@@ -669,7 +659,7 @@ namespace Pulumi.Docker
             }
         }
 
-        private static async Task WaitForExitAsync(Process process)
+        private static async Task StartAndWaitForExitAsync(Process process, string stdin)
         {
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -678,6 +668,16 @@ namespace Pulumi.Docker
 
             try
             {
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
+                if (stdin != null)
+                {
+                    process.StandardInput.Write(stdin);
+                    process.StandardInput.Close();
+                }
+
                 if (process.HasExited) return;
 
                 await tcs.Task.ConfigureAwait(false);


### PR DESCRIPTION
Fix #200

There is a race condition in the .NET SDK. As observed in a local test, `Exited` event may fire before the last `OutputDataReceived` call. If that happens, the last chunk of the output won't [be appended](https://github.com/pulumi/pulumi-docker/blob/395a9ac83377aa3ec290100dfd7c812db749100a/sdk/dotnet/Docker.cs#L608) to `stdout`. The `inspect` command returns a single chunk of output. If it's missing, the output is empty, and the exception `"No digest available for image"` is fired.

One possible fix would be to wait for a call with [`e.Data`](https://github.com/pulumi/pulumi-docker/blob/395a9ac83377aa3ec290100dfd7c812db749100a/sdk/dotnet/Docker.cs#L605) equal to `null` which signals the completion of the output. 

A simpler solution is suggested [here](https://stackoverflow.com/a/47322744/1171619) and implemented in this PR: make and extra `WaitForExit` call in the `ProcessExited` handler. This flushes the buffers and lets the output sync in. My local tests confirmed the improvement: I don't get the issue anymore.

Repro program that I used: https://gist.github.com/mikhailshilkov/978ae50e26c6e712c56fbd4d73b48222

In addition, I moved `Exited` event handler registration to before the `Start()` call to avoid a potential miss. (I believe this is not related to this issue, though.)

cc @Aaronontheweb  @dbeattie71