### PR TITLE
Improve build and push output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (Unreleased)
 * Upgrade to v2.9.0 of the Docker Terraform Provider
+* Improve build and push output [#251](https://github.com/pulumi/pulumi-docker/pull/251)
 
 ---
 

--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -49,7 +49,8 @@ func TestDotNet(t *testing.T) {
 		Dependencies: []string{
 			"Pulumi.Docker",
 		},
-		Dir: path.Join(cwd, "dotnet"),
+		Dir:                    path.Join(cwd, "dotnet"),
+		ExtraRuntimeValidation: dockerFileWithDependenciesOutputValidation,
 	})
 	integration.ProgramTest(t, &opts)
 }

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -49,7 +49,8 @@ func TestDockerfileGo(t *testing.T) {
 		Dependencies: []string{
 			"github.com/pulumi/pulumi-docker/sdk/v2",
 		},
-		Dir: path.Join(cwd, "dockerfile-go"),
+		Dir:                    path.Join(cwd, "dockerfile-go"),
+		ExtraRuntimeValidation: dockerFileWithDependenciesOutputValidation,
 	})
 	integration.ProgramTest(t, &opts)
 }

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -74,7 +74,8 @@ func TestDockerfileWithMultipleTargets(t *testing.T) {
 		Dependencies: []string{
 			"@pulumi/docker",
 		},
-		Dir: path.Join(cwd, "dockerfile-with-targets"),
+		Dir:                    path.Join(cwd, "dockerfile-with-targets"),
+		ExtraRuntimeValidation: dockerFileWithDependenciesOutputValidation,
 	})
 	integration.ProgramTest(t, &opts)
 }

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -62,7 +62,7 @@ func TestAzurePy(t *testing.T) {
 	opts := base.With(integration.ProgramTestOptions{
 		Config: map[string]string{
 			"azure:environment": "public",
-			"azure:location": location,
+			"azure:location":    location,
 		},
 		Dependencies: []string{
 			path.Join("..", "sdk", "python", "bin"),
@@ -97,7 +97,8 @@ func TestDockerfilePy(t *testing.T) {
 		Dependencies: []string{
 			path.Join("..", "sdk", "python", "bin"),
 		},
-		Dir: path.Join(cwd, "dockerfile-py"),
+		Dir:                    path.Join(cwd, "dockerfile-py"),
+		ExtraRuntimeValidation: dockerFileWithDependenciesOutputValidation,
 	})
 	integration.ProgramTest(t, &opts)
 }

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -488,6 +488,7 @@ github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/examples/util.go
+++ b/examples/util.go
@@ -22,6 +22,9 @@ import (
 )
 
 func dockerFileWithDependenciesOutputValidation(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+	// The full set of lines that are currently produced  are below, but some are commented out as they may not be
+	// stable going forward in case of changes to Docker.  To be safe, we just test a subset of this output that is
+	// enough to verify no structural regressions in the output.
 	expectedEphemeralDiagnosticsLines := []string{
 		"<{%reset%}>Building image '.'...<{%reset%}>\n",
 		//"<{%reset%}>Sending build context to Docker daemon  66.88MB<{%reset%}>\n",

--- a/examples/util.go
+++ b/examples/util.go
@@ -1,0 +1,49 @@
+// Copyright 2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v2/testing/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+func dockerFileWithDependenciesOutputValidation(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+	expectedEphemeralDiagnosticsLines := []string{
+		"<{%reset%}>Building image '.'...<{%reset%}>\n",
+		//"<{%reset%}>Sending build context to Docker daemon  66.88MB<{%reset%}>\n",
+		// "<{%reset%}><{%reset%}>\n",
+		"<{%reset%}>Step 1/3 : FROM python:3.6 AS base<{%reset%}>\n",
+		// "<{%reset%}> ---> bd4a91d81d7e<{%reset%}>\n",
+		// "<{%reset%}>Step 2/3 : FROM base AS dependencies<{%reset%}>\n",
+		// "<{%reset%}> ---> bd4a91d81d7e<{%reset%}>\n",
+		// "<{%reset%}>Step 3/3 : RUN pip install gunicorn<{%reset%}>\n",
+		// "<{%reset%}> ---> Using cache<{%reset%}>\n",
+		// "<{%reset%}> ---> 584bd8f8844a<{%reset%}>\n",
+		// "<{%reset%}>Successfully built 584bd8f8844a<{%reset%}>\n",
+		"<{%reset%}>Successfully tagged pulumi-user/example:v1.0.0<{%reset%}>\n",
+		// "<{%reset%}>sha256:584bd8f8844aeb5bc815c8c416b586a4334a577d49b1a4552a93765537c39151<{%reset%}>\n",
+		"<{%reset%}>Image build succeeded.<{%reset%}>\n",
+	}
+
+	var actualEphemeralDiagnosticsLines []string
+	for _, ev := range stack.Events {
+		if ev.DiagnosticEvent != nil && ev.DiagnosticEvent.Ephemeral && ev.DiagnosticEvent.Severity == "info" {
+			actualEphemeralDiagnosticsLines = append(actualEphemeralDiagnosticsLines, ev.DiagnosticEvent.Message)
+		}
+	}
+	assert.Subset(t, actualEphemeralDiagnosticsLines, expectedEphemeralDiagnosticsLines)
+}


### PR DESCRIPTION
Makes a variety of improvements to the log output of the build and push steps, both for cross-language consistency, and for a more focused and useful default display.

Improvements include:
* Significantly reduce the diagnostic-level output  - render just start/end notes for build and push steps - plus streamed output from docker build and docker push.
* Keep diagnostic logs as "debug" level logs
* Correctly stream stdout to ephemeral logs for Go
* Fix incorrect newline handling of streamed stdout in Node.js
* Add tests of CLI output