### PR TITLE
Create CacheFromPtr interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ _(none)_
 
 ---
 
+## 3.0.1 (2021-06-21)
+* Fix the compilation bug with CacheFrom in the go sdk
+
 ## 3.0.0 (2021-04-19)
 * Depend on Pulumi 3.0, which includes improvements to Python resource arguments and key translation, Go SDK performance,
   Node SDK performance, general availability of Automation API, and more.

--- a/sdk/go/docker/customTypes.go
+++ b/sdk/go/docker/customTypes.go
@@ -39,6 +39,47 @@ func (i CacheFromArgs) ToCacheFromOutputWithContext(ctx context.Context) CacheFr
 	return pulumi.ToOutputWithContext(ctx, i).(CacheFromOutput)
 }
 
+func (i CacheFromArgs) ToCacheFromPtrOutput() CacheFromPtrOutput {
+	return i.ToCacheFromPtrOutputWithContext(context.Background())
+}
+
+func (i CacheFromArgs) ToCacheFromPtrOutputWithContext(ctx context.Context) CacheFromPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(CacheFromOutput).ToCacheFromPtrOutputWithContext(ctx)
+}
+
+// CacheFromPtrInput is an input type that accepts CacheFromArgs, CacheFromPtr and CacheFromPtrOutput values.
+// You can construct a concrete instance of `CacheFromPtrInput` via:
+//
+//          CacheFromArgs{...}
+//
+//  or:
+//
+//          nil
+type CacheFromPtrInput interface {
+	pulumi.Input
+
+	ToCacheFromPtrOutput() CacheFromPtrOutput
+	ToCacheFromPtrOutputWithContext(context.Context) CacheFromPtrOutput
+}
+
+type CacheFromPtrType CacheFromArgs
+
+func CacheFromPtr(v *CacheFromArgs) CacheFromPtrInput {
+	return (*CacheFromPtrType)(v)
+}
+
+func (*CacheFromPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**CacheFrom)(nil)).Elem()
+}
+
+func (i *CacheFromPtrType) ToCacheFromPtrOutput() CacheFromPtrOutput {
+	return i.ToCacheFromPtrOutputWithContext(context.Background())
+}
+
+func (i *CacheFromPtrType) ToCacheFromPtrOutputWithContext(ctx context.Context) CacheFromPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(CacheFromPtrOutput)
+}
+
 type CacheFromOutput struct{ *pulumi.OutputState }
 
 func (CacheFromOutput) ElementType() reflect.Type {
@@ -51,6 +92,35 @@ func (o CacheFromOutput) ToCacheFromOutput() CacheFromOutput {
 
 func (o CacheFromOutput) ToCacheFromOutputWithContext(ctx context.Context) CacheFromOutput {
 	return o
+}
+
+func (o CacheFromOutput) ToCacheFromPtrOutput() CacheFromPtrOutput {
+	return o.ToCacheFromPtrOutputWithContext(context.Background())
+}
+
+func (o CacheFromOutput) ToCacheFromPtrOutputWithContext(ctx context.Context) CacheFromPtrOutput {
+	return o.ApplyT(func(v CacheFrom) *CacheFrom {
+		return &v
+	}).(CacheFromPtrOutput)
+}
+
+
+type CacheFromPtrOutput struct{ *pulumi.OutputState }
+
+func (CacheFromPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**CacheFrom)(nil)).Elem()
+}
+
+func (o CacheFromPtrOutput) ToCacheFromPtrOutput() CacheFromPtrOutput {
+	return o
+}
+
+func (o CacheFromPtrOutput) ToCacheFromPtrOutputWithContext(ctx context.Context) CacheFromPtrOutput {
+	return o
+}
+
+func (o CacheFromPtrOutput) Elem() CacheFromOutput {
+	return o.ApplyT(func(v *CacheFrom) CacheFrom { return *v }).(CacheFromOutput)
 }
 
 // DockerBuild is a copy of DockerBuildArgs but without using TInput in types.
@@ -88,7 +158,7 @@ type DockerBuildArgs struct {
 	// build cache.  This parameter maps to the --cache-from argument to the Docker CLI. If this
 	// parameter is `true`, only the final image will be pulled and passed to --cache-from; if it is
 	// a CacheFrom object, the stages named therein will also be pulled and passed to --cache-from.
-	CacheFrom CacheFromInput `pulumi:"cacheFrom"`
+	CacheFrom CacheFromPtrInput `pulumi:"cacheFrom"`
 
 	// An optional catch-all list of arguments to provide extra CLI options to the docker build command.
 	// For example `{'--network', 'host'}`.


### PR DESCRIPTION
Fixes #238. Create the CacheFromPtr interface and supporting types to fix the CacheFrom compilation issue for the go sdk.

Note, I mostly have no idea what I'm doing and I'm going off the suggestion of making a pointer type from the linked issue. I used https://github.com/pulumi/pulumi-gcp/blob/master/sdk/go/gcp/sql/pulumiTypes.go#L1064 as inspiration for how to set this up (I'm now realizing as I write this PR that this may not be the optimal source of inspiration).

I also don't know how to test this change and would love feedback on that front.