### PR TITLE
Fix various go linting issues

### DIFF
--- a/sdk/go/docker/customTypes.go
+++ b/sdk/go/docker/customTypes.go
@@ -54,7 +54,7 @@ func (o CacheFromOutput) ToCacheFromOutputWithContext(ctx context.Context) Cache
 }
 
 // DockerBuild is a copy of DockerBuildArgs but without using TInput in types.
-// nolint[:golint]
+// nolint:golint
 type DockerBuild struct {
 	Context      string            `pulumi:"context"`
 	Dockerfile   string            `pulumi:"dockerfile"`
@@ -66,7 +66,7 @@ type DockerBuild struct {
 }
 
 // DockerBuildArgs may be used to specify detailed instructions about how to build a container.
-// nolint[:golint]
+// nolint:golint
 type DockerBuildArgs struct {
 	// Context is a path to a directory to use for the Docker build context, usually the directory
 	// in which the Dockerfile resides (although dockerfile may be used to choose a custom location
@@ -102,7 +102,7 @@ type DockerBuildArgs struct {
 	Target pulumi.StringInput `pulumi:"target"`
 }
 
-// nolint[:golint]
+// nolint:golint
 type DockerBuildInput interface {
 	pulumi.Input
 
@@ -122,7 +122,7 @@ func (i DockerBuildArgs) ToDockerBuildOutputWithContext(ctx context.Context) Doc
 	return pulumi.ToOutputWithContext(ctx, i).(DockerBuildOutput)
 }
 
-// nolint[:golint]
+// nolint:golint
 type DockerBuildOutput struct{ *pulumi.OutputState }
 
 func (DockerBuildOutput) ElementType() reflect.Type {

--- a/sdk/go/docker/docker.go
+++ b/sdk/go/docker/docker.go
@@ -118,7 +118,7 @@ func buildAndPushImage(ctx *pulumi.Context, baseImageName string, build *DockerB
 	return uniqueTaggedImageName, nil
 }
 
-func pullCache(ctx *pulumi.Context, imageName string, cacheFrom CacheFrom, repoURL string, logResource pulumi.Resource) []string { // nolint[:lll]
+func pullCache(ctx *pulumi.Context, imageName string, cacheFrom CacheFrom, repoURL string, logResource pulumi.Resource) []string { // nolint:lll
 	if len(repoURL) == 0 {
 		return nil
 	}
@@ -225,7 +225,7 @@ func buildImage(ctx *pulumi.Context, imageName string, build *DockerBuild,
 	// If the container build specified build stages to cache, build each in turn.
 	var stages []string
 	if build.CacheFrom != nil && build.CacheFrom.Stages != nil {
-		for _, stage := range stages {
+		for _, stage := range build.CacheFrom.Stages {
 			err := runDockerBuild(ctx, localStageImageName(imageName, stage), build, cacheFrom, logResource, stage)
 			if err != nil {
 				return "", nil, err
@@ -369,13 +369,12 @@ func useDockerPasswordStdin(ctx *pulumi.Context, logResource pulumi.Resource) (b
 
 func runDockerBuild(ctx *pulumi.Context, imageName string, build *DockerBuild, cacheFrom []string,
 	logResource pulumi.Resource, target string) error {
-
+	if build == nil {
+		return fmt.Errorf("build field required for running docker build")
+	}
 	// Prepare the build arguments.
 	buildArgs := []string{"build"}
-	if build != nil {
-		// Add a custom Dockerfile location.
-		buildArgs = append(buildArgs, "-f", build.Dockerfile)
-	}
+	buildArgs = append(buildArgs, "-f", build.Dockerfile)
 	if build.Args != nil {
 		for k, v := range build.Args {
 			buildArgs = append(buildArgs, "--build-arg", fmt.Sprintf("%s=%s", k, v))
@@ -457,7 +456,7 @@ func runCommandThatCanFail(ctx *pulumi.Context, cmdName string, args []string, l
 	// which the grpc layer needs.
 	streamID := rand.Int31() // #nosec
 
-	// nolint[:errcheck]
+	// nolint:errcheck
 	logErrorf := func(format string, a ...interface{}) {
 		ctx.Log.Error(fmt.Sprintf(format, a...), &pulumi.LogArgs{
 			Resource: logResource,
@@ -487,7 +486,7 @@ func runCommandThatCanFail(ctx *pulumi.Context, cmdName string, args []string, l
 		}
 		go func() {
 			defer stdin.Close()
-			// nolint[:errcheck]
+			// nolint:errcheck
 			io.WriteString(stdin, stdinInput)
 		}()
 	}
@@ -534,7 +533,7 @@ func runCommandThatCanFail(ctx *pulumi.Context, cmdName string, args []string, l
 			logErrorf(stderrString)
 		} else {
 			// Command succeeded.  These were just a warning.
-			// nolint[:errcheck]
+			// nolint:errcheck
 			ctx.Log.Warn(stderrString, &pulumi.LogArgs{
 				Resource:  logResource,
 				StreamID:  streamID,
@@ -574,7 +573,7 @@ func getCommandLineMessage(cmd string, args []string, reportFullCommandLine bool
 	return fmt.Sprintf("%s %s", cmd, argString)
 }
 
-// nolint[:errcheck]
+// nolint:errcheck
 func logEphemeral(ctx *pulumi.Context, msg string, logResource pulumi.Resource) {
 	ctx.Log.Info(msg, &pulumi.LogArgs{
 		Resource:  logResource,
@@ -582,7 +581,7 @@ func logEphemeral(ctx *pulumi.Context, msg string, logResource pulumi.Resource) 
 	})
 }
 
-// nolint[:errcheck]
+// nolint:errcheck
 func logDebug(ctx *pulumi.Context, msg string, logResource pulumi.Resource) {
 	ctx.Log.Debug(msg, &pulumi.LogArgs{
 		Resource:  logResource,

--- a/sdk/go/docker/image.go
+++ b/sdk/go/docker/image.go
@@ -84,7 +84,7 @@ func NewImage(ctx *pulumi.Context,
 	}).(pulumi.StringOutput)
 
 	if args != nil && args.Registry != nil {
-		resource.RegistryServer = args.Registry.ToImageRegistryOutput().ApplyT(func(registry ImageRegistry) (string, error) { // nolint[:lll]
+		resource.RegistryServer = args.Registry.ToImageRegistryOutput().ApplyT(func(registry ImageRegistry) (string, error) { // nolint:lll
 			return registry.Server, nil
 		}).(pulumi.StringOutput)
 	}


### PR DESCRIPTION
Looks like we are using `golangci/golangci-lint:latest` for running linting and perhaps the format for specifying nolints has recently changed. Also fixes a bug related to `cache_from` handling. This is independent of https://github.com/pulumi/pulumi-docker/issues/238