### PR TITLE
Fix passing of env variables to docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## HEAD (Unreleased)
-_(none)_
+* Fix passing of `env` parameter in `docker.DockerBuildArgs` in the Python SDK [#310](https://github.com/pulumi/pulumi-docker/issues/310)
 
 ---
 

--- a/sdk/python/pulumi_docker/docker.py
+++ b/sdk/python/pulumi_docker/docker.py
@@ -655,7 +655,9 @@ def run_command_that_can_fail(
     cmd.extend(args)
 
     if env is not None:
-        env = os.environ.copy().update(env)
+        environ = os.environ.copy()
+        environ.update(env)
+        env = environ
 
     process = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE, stdin=subprocess.PIPE, encoding="utf-8")


### PR DESCRIPTION
Fixes #310 

The `update()` method modifies a dictionary and returns `None`, not the modified dictionary. The original code passed this return value from `update()` to `subprocess.Popen()` as the environment variables rather than the dictionary which was updated. This PR fixes this by passing the modified dictionary.