### PR TITLE
Don't block the message loop on Docker builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## HEAD (Unreleased)
 * Upgrade to terraform-bridge 3.11.0
 * Upgrade to pulumi 3.17.0
+* Avoid blocking the message loop for Docker builds in Python
+  [#314](https://github.com/pulumi/pulumi-docker/pull/314).
 
 ---
 

--- a/sdk/python/pulumi_docker/docker.py
+++ b/sdk/python/pulumi_docker/docker.py
@@ -652,9 +652,6 @@ async def run_command_that_can_fail(
     # which the grpc layer needs.
     stream_id = math.floor(random() * (1 << 30))
 
-    cmd = [cmd_name]
-    cmd.extend(args)
-
     if env is not None:
         env = os.environ.copy().update(env)
 

--- a/sdk/python/pulumi_docker/docker.py
+++ b/sdk/python/pulumi_docker/docker.py
@@ -16,7 +16,6 @@ import json
 import math
 import os
 import re
-import subprocess
 from random import random
 from typing import Optional, Union, List, Mapping, Sequence
 from distutils.version import LooseVersion
@@ -657,7 +656,7 @@ async def run_command_that_can_fail(
 
     process = await asyncio.create_subprocess_exec(
         cmd_name, *args, env=env,
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, stdin=asyncio.subprocess.PIPE)
 
     # We store the results from stdout in memory and will return them as a str.
     stdout_chunks: List[str] = []


### PR DESCRIPTION
This swaps out subprocess.Popen and communicate calls, which
block, when invoking the Docker CLI, and instead uses
asyncio.create_subprocess_exec, which offers equivalent functionlity
without blocking the message loop.

This addresses the responsiveness issues and behaves better with
the Pulumi CLI. In particular, for lengthy builds, we no longer
interfere with the ability of the CLI to report progress and display
resources as they are created by the program, asynchronously
interleaved amongst the build itself.

This is technically a breaking change, however, because the
functions now return futures where they used to return raw values.
It would be reasonable to, instead of changing these in place,
turn them into _async routines (which are used internally), and
then have thin wrappers that block alongside them.

This change fixes #313.