### PR TITLE
Update Goreleaser and deprecate CHANGELOG

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,8 @@ builds:
   - -X github.com/pulumi/pulumi-docker/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-docker/
 changelog:
-  skip: true
+  use: git
+  sort: asc
 release:
   disable: false
 snapshot:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Notice (2022-01-06)
+
+*As of this notice, using CHANGELOG.md is DEPRECATED. We will be using [GitHub Releases](https://github.com/pulumi/pulumi-docker/releases) for this repository*
+
 ## HEAD (Unreleased)
 * Upgrade to terraform-bridge 3.11.0
 * Upgrade to pulumi 3.17.0


### PR DESCRIPTION
Part of https://github.com/pulumi/release-bot/issues/13