### PR TITLE
[internal] Ensure DotNet dependencies match those upstream

### DIFF
--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -5127,8 +5127,7 @@
                 "docker": "Docker"
             },
             "packageReferences": {
-                "Pulumi": "3.*",
-                "Semver": "2.0.6"
+                "Pulumi": "3.*"
             }
         },
         "go": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -158,7 +158,6 @@ func Provider() tfbridge.ProviderInfo {
 		CSharp: &tfbridge.CSharpInfo{
 			PackageReferences: map[string]string{
 				"Pulumi": "3.*",
-				"Semver": "2.0.6",
 			},
 			Namespaces: map[string]string{
 				dockerPkg: "Docker",

--- a/sdk/dotnet/Pulumi.Docker.csproj
+++ b/sdk/dotnet/Pulumi.Docker.csproj
@@ -46,7 +46,6 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Semver" Version="2.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes: #357

We want to inherit the upstream dep from Pulumi not override it otherwise we get a downgrade warning with Nuget