### PR TITLE
Add VERSION_PREFIX to prerelease Action

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TRAVIS_OS_NAME: linux
+  VERSION_PREFIX: 4.0.0
+
 jobs:
   build_sdk:
     name: build_sdk


### PR DESCRIPTION
On an alpha release, we run the prerelease action. pulumictl needs to read a version prefix, otherwise the Go SDK will fail to build.

