### PR TITLE
Add Unit Tests for Input Parsing

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -60,7 +60,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 	}
 
 	build := marshalBuildAndApplyDefaults(inputs["build"])
-	cache := getCachedImages(img, inputs["build"])
+	cache := marshalCachedImages(img, inputs["build"])
 
 	build.CachedImages = cache
 	img.Build = build
@@ -234,10 +234,10 @@ func marshalBuildAndApplyDefaults(b resource.PropertyValue) Build {
 	}
 	// Envs
 
-	build.Env = setEnvs(buildObject["env"])
+	build.Env = marshalEnvs(buildObject["env"])
 
 	// Args
-	build.Args = setArgs(buildObject["args"])
+	build.Args = marshalArgs(buildObject["args"])
 
 	// ExtraOptions
 	if !buildObject["extraOptions"].IsNull() {
@@ -254,7 +254,7 @@ func marshalBuildAndApplyDefaults(b resource.PropertyValue) Build {
 	return build
 }
 
-func getCachedImages(img Image, b resource.PropertyValue) []string {
+func marshalCachedImages(img Image, b resource.PropertyValue) []string {
 	var cacheImages []string
 	if b.IsNull() {
 		return cacheImages
@@ -300,7 +300,7 @@ func setRegistry(r resource.PropertyValue) Registry {
 	return reg
 }
 
-func setArgs(a resource.PropertyValue) map[string]*string {
+func marshalArgs(a resource.PropertyValue) map[string]*string {
 	args := make(map[string]*string)
 	if !a.IsNull() {
 		for k, v := range a.ObjectValue() {
@@ -315,7 +315,7 @@ func setArgs(a resource.PropertyValue) map[string]*string {
 	return args
 }
 
-func setEnvs(e resource.PropertyValue) map[string]string {
+func marshalEnvs(e resource.PropertyValue) map[string]string {
 	envs := make(map[string]string)
 	if !e.IsNull() {
 		for k, v := range e.ObjectValue() {

--- a/provider/image.go
+++ b/provider/image.go
@@ -59,7 +59,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		Registry: reg,
 	}
 
-	build := marshalBuild(inputs["build"])
+	build := marshalBuildAndApplyDefaults(inputs["build"])
 	cache := getCachedImages(img, inputs["build"])
 
 	build.CachedImages = cache
@@ -199,7 +199,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 	return img.Name, pbstruct, err
 }
 
-func marshalBuild(b resource.PropertyValue) Build {
+func marshalBuildAndApplyDefaults(b resource.PropertyValue) Build {
 
 	// build can be nil, a string or an object; we will also use reasonable defaults here.
 	var build Build

--- a/provider/image.go
+++ b/provider/image.go
@@ -213,8 +213,6 @@ func marshalBuild(b resource.PropertyValue) Build {
 		// use the filepath as context
 		build.Context = b.StringValue()
 		build.Dockerfile = defaultDockerfile
-		build.Env = make(map[string]string)
-		build.Args = make(map[string]*string)
 		return build
 	}
 
@@ -311,6 +309,9 @@ func setArgs(a resource.PropertyValue) map[string]*string {
 			args[key] = &vStr
 		}
 	}
+	if len(args) == 0 {
+		return nil
+	}
 	return args
 }
 
@@ -321,6 +322,9 @@ func setEnvs(e resource.PropertyValue) map[string]string {
 			key := fmt.Sprintf("%v", k)
 			envs[key] = v.StringValue()
 		}
+	}
+	if len(envs) == 0 {
+		return nil
 	}
 	return envs
 }

--- a/provider/image.go
+++ b/provider/image.go
@@ -235,25 +235,11 @@ func marshalBuild(b resource.PropertyValue) Build {
 		build.Context = buildObject["context"].StringValue()
 	}
 	// Envs
-	envs := make(map[string]string)
-	if !buildObject["env"].IsNull() {
-		for k, v := range buildObject["env"].ObjectValue() {
-			key := fmt.Sprintf("%v", k)
-			envs[key] = v.StringValue()
-		}
-	}
-	build.Env = envs
+
+	build.Env = setEnvs(buildObject["env"])
 
 	// Args
-	args := make(map[string]*string)
-	if !buildObject["args"].IsNull() {
-		for k, v := range buildObject["args"].ObjectValue() {
-			key := fmt.Sprintf("%v", k)
-			vStr := v.StringValue()
-			args[key] = &vStr
-		}
-	}
-	build.Args = args
+	build.Args = setArgs(buildObject["args"])
 
 	// ExtraOptions
 	if !buildObject["extraOptions"].IsNull() {
@@ -315,4 +301,27 @@ func setRegistry(r resource.PropertyValue) Registry {
 		return reg
 	}
 	return reg
+}
+
+func setArgs(a resource.PropertyValue) map[string]*string {
+	args := make(map[string]*string)
+	if !a.IsNull() {
+		for k, v := range a.ObjectValue() {
+			key := fmt.Sprintf("%v", k)
+			vStr := v.StringValue()
+			args[key] = &vStr
+		}
+	}
+	return args
+}
+
+func setEnvs(e resource.PropertyValue) map[string]string {
+	envs := make(map[string]string)
+	if !e.IsNull() {
+		for k, v := range e.ObjectValue() {
+			key := fmt.Sprintf("%v", k)
+			envs[key] = v.StringValue()
+		}
+	}
+	return envs
 }

--- a/provider/image.go
+++ b/provider/image.go
@@ -301,9 +301,15 @@ func getCachedImages(img Image, b resource.PropertyValue) []string {
 func setRegistry(r resource.PropertyValue) Registry {
 	var reg Registry
 	if !r.IsNull() {
-		reg.Server = r.ObjectValue()["server"].StringValue()
-		reg.Username = r.ObjectValue()["username"].StringValue()
-		reg.Password = r.ObjectValue()["password"].StringValue()
+		if !r.ObjectValue()["server"].IsNull() {
+			reg.Server = r.ObjectValue()["server"].StringValue()
+		}
+		if !r.ObjectValue()["username"].IsNull() {
+			reg.Username = r.ObjectValue()["username"].StringValue()
+		}
+		if !r.ObjectValue()["password"].IsNull() {
+			reg.Password = r.ObjectValue()["password"].StringValue()
+		}
 		return reg
 	}
 	return reg

--- a/provider/image.go
+++ b/provider/image.go
@@ -257,7 +257,6 @@ func marshalBuild(b resource.PropertyValue) Build {
 }
 
 func getCachedImages(img Image, b resource.PropertyValue) []string {
-
 	var cacheImages []string
 	if b.IsNull() {
 		return cacheImages

--- a/provider/image.go
+++ b/provider/image.go
@@ -203,7 +203,6 @@ func marshalBuild(b resource.PropertyValue) Build {
 
 	// build can be nil, a string or an object; we will also use reasonable defaults here.
 	var build Build
-
 	if b.IsNull() {
 		// use the default build context
 		build.Dockerfile = defaultDockerfile
@@ -214,6 +213,8 @@ func marshalBuild(b resource.PropertyValue) Build {
 		// use the filepath as context
 		build.Context = b.StringValue()
 		build.Dockerfile = defaultDockerfile
+		build.Env = make(map[string]string)
+		build.Args = make(map[string]*string)
 		return build
 	}
 
@@ -242,6 +243,7 @@ func marshalBuild(b resource.PropertyValue) Build {
 		}
 	}
 	build.Env = envs
+
 	// Args
 	args := make(map[string]*string)
 	if !buildObject["args"].IsNull() {

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -1,0 +1,1 @@
+package provider

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -8,45 +8,45 @@ import (
 
 func TestSetRegistry(t *testing.T) {
 
-	expectedRegistry := Registry{
-		Server:   "https://index.docker.io/v1/",
-		Username: "pulumipus",
-		Password: "supersecret",
-	}
+	t.Run("Valid Registry", func(t *testing.T) {
+		expected := Registry{
+			Server:   "https://index.docker.io/v1/",
+			Username: "pulumipus",
+			Password: "supersecret",
+		}
+		input := resource.PropertyValue{
+			resource.NewPropertyMapFromMap(map[string]interface{}{
+				"server":   "https://index.docker.io/v1/",
+				"username": "pulumipus",
+				"password": "supersecret",
+			}),
+		}
 
-	expectedRegistryIncomplete := Registry{
-		Server:   "https://index.docker.io/v1/",
-		Username: "pulumipus",
-	}
+		actual := setRegistry(input)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Incomplete Registry sets all available fields", func(t *testing.T) {
+		expected := Registry{
+			Server:   "https://index.docker.io/v1/",
+			Username: "pulumipus",
+		}
+		input := resource.PropertyValue{
+			resource.NewPropertyMapFromMap(map[string]interface{}{
+				"server":   "https://index.docker.io/v1/",
+				"username": "pulumipus",
+			}),
+		}
 
-	expectedRegistryNil := Registry{}
+		actual := setRegistry(input)
+		assert.Equal(t, expected, actual)
+	})
 
-	testRegistryValidInput := resource.PropertyValue{
-		resource.NewPropertyMapFromMap(map[string]interface{}{
-			"server":   "https://index.docker.io/v1/",
-			"username": "pulumipus",
-			"password": "supersecret",
-		}),
-	}
-
-	testRegistryIncompleteInput := resource.PropertyValue{
-		resource.NewPropertyMapFromMap(map[string]interface{}{
-			"server":   "https://index.docker.io/v1/",
-			"username": "pulumipus",
-		}),
-	}
-
-	testRegistryNilInput := resource.PropertyValue{}
-
-	testRegistryValid := setRegistry(testRegistryValidInput)
-	testRegistryIncomplete := setRegistry(testRegistryIncompleteInput)
-	testRegistryNil := setRegistry(testRegistryNilInput)
-
-	assert.Equal(t, expectedRegistry, testRegistryValid)
-	assert.NotEqual(t, expectedRegistry, testRegistryIncomplete)
-	assert.Equal(t, expectedRegistryIncomplete, testRegistryIncomplete)
-	assert.Equal(t, expectedRegistryNil, testRegistryNil)
-
+	t.Run("Registry can be nil", func(t *testing.T) {
+		expected := Registry{}
+		input := resource.PropertyValue{}
+		actual := setRegistry(input)
+		assert.Equal(t, expected, actual)
+	})
 }
 
 func TestMarshalBuild(t *testing.T) {

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -165,11 +165,17 @@ func TestSetArgs(t *testing.T) {
 		actual := setArgs(input)
 		assert.Equal(t, expected, actual)
 	})
+
+	t.Run("No args set", func(t *testing.T) {
+		expected := map[string]*string{}
+		input := resource.NewObjectProperty(resource.PropertyMap{})
+		actual := setArgs(input)
+		assert.Equal(t, expected, actual)
+	})
 }
 
 func TestSetEnvs(t *testing.T) {
 	t.Run("Set any environment variables", func(t *testing.T) {
-
 		expected := map[string]string{
 			"Strawberry": "fruit",
 			"Carrot":     "veggie",
@@ -181,6 +187,77 @@ func TestSetEnvs(t *testing.T) {
 			"Docker":     resource.NewStringProperty("a bit of a mess tbh"),
 		})
 		actual := setEnvs(input)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("No environment variables", func(t *testing.T) {
+		expected := map[string]string{}
+		input := resource.NewObjectProperty(resource.PropertyMap{})
+		actual := setEnvs(input)
+		assert.Equal(t, expected, actual)
+	})
+}
+
+func TestGetCachedImages(t *testing.T) {
+	t.Run("Test Cached Images", func(t *testing.T) {
+		expected := []string{"apple", "banana", "cherry"}
+		imgInput := Image{
+			Name:     "unicornsareawesome",
+			SkipPush: false,
+			Registry: Registry{
+				Server:   "https://index.docker.io/v1/",
+				Username: "pulumipus",
+				Password: "supersecret",
+			},
+		}
+		buildInput := resource.NewObjectProperty(resource.PropertyMap{
+			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
+			"context":    resource.NewStringProperty("/twilight/sparkle/bin"),
+
+			"cacheFrom": resource.NewObjectProperty(resource.PropertyMap{
+				"stages": resource.NewArrayProperty([]resource.PropertyValue{
+					resource.NewStringProperty("apple"),
+					resource.NewStringProperty("banana"),
+					resource.NewStringProperty("cherry"),
+				}),
+			}),
+		})
+
+		actual := getCachedImages(imgInput, buildInput)
+		assert.Equal(t, expected, actual)
+
+	})
+	t.Run("Test Cached Images No Build Input Returns Nil", func(t *testing.T) {
+		expected := []string(nil)
+		imgInput := Image{
+			Name:     "unicornsareawesome",
+			SkipPush: false,
+			Registry: Registry{
+				Server:   "https://index.docker.io/v1/",
+				Username: "pulumipus",
+				Password: "supersecret",
+			},
+		}
+		buildInput := resource.NewObjectProperty(resource.PropertyMap{})
+		actual := getCachedImages(imgInput, buildInput)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("Test Cached Images No cacheFrom Input Returns Nil", func(t *testing.T) {
+		expected := []string(nil)
+		imgInput := Image{
+			Name:     "unicornsareawesome",
+			SkipPush: false,
+			Registry: Registry{
+				Server:   "https://index.docker.io/v1/",
+				Username: "pulumipus",
+				Password: "supersecret",
+			},
+		}
+		buildInput := resource.NewObjectProperty(resource.PropertyMap{
+			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
+			"context":    resource.NewStringProperty("/twilight/sparkle/bin"),
+		})
+		actual := getCachedImages(imgInput, buildInput)
 		assert.Equal(t, expected, actual)
 	})
 }

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -45,17 +45,15 @@ func TestSetRegistry(t *testing.T) {
 	})
 }
 
-func TestMarshalBuild(t *testing.T) {
+func TestMarshalBuildAndApplyDefaults(t *testing.T) {
 
 	t.Run("Default Build on empty input", func(t *testing.T) {
 		expected := Build{
 			Context:    ".",
 			Dockerfile: "Dockerfile",
 		}
-		input := resource.PropertyValue{
-			resource.NewPropertyMapFromMap(map[string]interface{}{}),
-		}
-		actual := marshalBuild(input)
+		input := resource.NewObjectProperty(resource.PropertyMap{})
+		actual := marshalBuildAndApplyDefaults(input)
 		assert.Equal(t, expected, actual)
 	})
 
@@ -65,7 +63,7 @@ func TestMarshalBuild(t *testing.T) {
 			Dockerfile: "Dockerfile",
 		}
 		input := resource.NewStringProperty("/twilight/sparkle/bin")
-		actual := marshalBuild(input)
+		actual := marshalBuildAndApplyDefaults(input)
 		assert.Equal(t, expected, actual)
 	})
 
@@ -77,7 +75,7 @@ func TestMarshalBuild(t *testing.T) {
 		input := resource.NewObjectProperty(resource.PropertyMap{
 			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
 		})
-		actual := marshalBuild(input)
+		actual := marshalBuildAndApplyDefaults(input)
 		assert.Equal(t, expected, actual)
 	})
 
@@ -91,7 +89,7 @@ func TestMarshalBuild(t *testing.T) {
 			"context":    resource.NewStringProperty("/twilight/sparkle/bin"),
 		})
 
-		actual := marshalBuild(input)
+		actual := marshalBuildAndApplyDefaults(input)
 		assert.Equal(t, expected, actual)
 	})
 
@@ -111,7 +109,7 @@ func TestMarshalBuild(t *testing.T) {
 			}),
 		})
 
-		actual := marshalBuild(input)
+		actual := marshalBuildAndApplyDefaults(input)
 		assert.Equal(t, expected, actual)
 	})
 
@@ -131,7 +129,7 @@ func TestMarshalBuild(t *testing.T) {
 			}),
 		})
 
-		actual := marshalBuild(input)
+		actual := marshalBuildAndApplyDefaults(input)
 		assert.Equal(t, expected, actual)
 	})
 
@@ -150,7 +148,7 @@ func TestMarshalBuild(t *testing.T) {
 			}),
 		})
 
-		actual := marshalBuild(input)
+		actual := marshalBuildAndApplyDefaults(input)
 		assert.Equal(t, expected, actual)
 	})
 
@@ -164,7 +162,7 @@ func TestMarshalBuild(t *testing.T) {
 			"extraOptions": resource.NewArrayProperty([]resource.PropertyValue{}),
 		})
 
-		actual := marshalBuild(input)
+		actual := marshalBuildAndApplyDefaults(input)
 		assert.Equal(t, expected, actual)
 	})
 	t.Run("Sets Target", func(t *testing.T) {
@@ -178,7 +176,7 @@ func TestMarshalBuild(t *testing.T) {
 			"target": resource.NewStringProperty("bullseye"),
 		})
 
-		actual := marshalBuild(input)
+		actual := marshalBuildAndApplyDefaults(input)
 		assert.Equal(t, expected, actual)
 	})
 }
@@ -297,4 +295,3 @@ func TestGetCachedImages(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 }
-

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -1,1 +1,50 @@
 package provider
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSetRegistry(t *testing.T) {
+
+	expectedRegistry := Registry{
+		Server:   "https://index.docker.io/v1/",
+		Username: "pulumipus",
+		Password: "supersecret",
+	}
+
+	expectedRegistryIncomplete := Registry{
+		Server:   "https://index.docker.io/v1/",
+		Username: "pulumipus",
+	}
+
+	expectedRegistryNil := Registry{}
+
+	testRegistryValidInput := resource.PropertyValue{
+		resource.NewPropertyMapFromMap(map[string]interface{}{
+			"server":   "https://index.docker.io/v1/",
+			"username": "pulumipus",
+			"password": "supersecret",
+		}),
+	}
+
+	testRegistryIncompleteInput := resource.PropertyValue{
+		resource.NewPropertyMapFromMap(map[string]interface{}{
+			"server":   "https://index.docker.io/v1/",
+			"username": "pulumipus",
+		}),
+	}
+
+	testRegistryNilInput := resource.PropertyValue{}
+
+	testRegistryValid := setRegistry(testRegistryValidInput)
+	testRegistryIncomplete := setRegistry(testRegistryIncompleteInput)
+	testRegistryNil := setRegistry(testRegistryNilInput)
+
+	assert.Equal(t, testRegistryValid, expectedRegistry)
+	assert.NotEqual(t, testRegistryIncomplete, expectedRegistry)
+	assert.Equal(t, testRegistryIncomplete, expectedRegistryIncomplete)
+	assert.Equal(t, testRegistryNil, expectedRegistryNil)
+
+}

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -181,7 +181,7 @@ func TestMarshalBuildAndApplyDefaults(t *testing.T) {
 	})
 }
 
-func TestSetArgs(t *testing.T) {
+func TestMarshalArgs(t *testing.T) {
 	t.Run("Set any args", func(t *testing.T) {
 		a := "Alicorn"
 		p := "Pegasus"
@@ -196,19 +196,19 @@ func TestSetArgs(t *testing.T) {
 			"Fledge":    resource.NewStringProperty("Pegasus"),
 			"The Last":  resource.NewStringProperty("Unicorn"),
 		})
-		actual := setArgs(input)
+		actual := marshalArgs(input)
 		assert.Equal(t, expected, actual)
 	})
 
 	t.Run("Returns nil when no args set", func(t *testing.T) {
 		expected := map[string]*string(nil)
 		input := resource.NewObjectProperty(resource.PropertyMap{})
-		actual := setArgs(input)
+		actual := marshalArgs(input)
 		assert.Equal(t, expected, actual)
 	})
 }
 
-func TestSetEnvs(t *testing.T) {
+func TestMarshalEnvs(t *testing.T) {
 	t.Run("Set any environment variables", func(t *testing.T) {
 		expected := map[string]string{
 			"Strawberry": "fruit",
@@ -220,18 +220,18 @@ func TestSetEnvs(t *testing.T) {
 			"Carrot":     resource.NewStringProperty("veggie"),
 			"Docker":     resource.NewStringProperty("a bit of a mess tbh"),
 		})
-		actual := setEnvs(input)
+		actual := marshalEnvs(input)
 		assert.Equal(t, expected, actual)
 	})
 	t.Run("Returns nil when no environment variables set", func(t *testing.T) {
 		expected := map[string]string(nil)
 		input := resource.NewObjectProperty(resource.PropertyMap{})
-		actual := setEnvs(input)
+		actual := marshalEnvs(input)
 		assert.Equal(t, expected, actual)
 	})
 }
 
-func TestGetCachedImages(t *testing.T) {
+func TestMarshalCachedImages(t *testing.T) {
 	t.Run("Test Cached Images", func(t *testing.T) {
 		expected := []string{"apple", "banana", "cherry"}
 		imgInput := Image{
@@ -256,7 +256,7 @@ func TestGetCachedImages(t *testing.T) {
 			}),
 		})
 
-		actual := getCachedImages(imgInput, buildInput)
+		actual := marshalCachedImages(imgInput, buildInput)
 		assert.Equal(t, expected, actual)
 
 	})
@@ -272,7 +272,7 @@ func TestGetCachedImages(t *testing.T) {
 			},
 		}
 		buildInput := resource.NewObjectProperty(resource.PropertyMap{})
-		actual := getCachedImages(imgInput, buildInput)
+		actual := marshalCachedImages(imgInput, buildInput)
 		assert.Equal(t, expected, actual)
 	})
 
@@ -291,7 +291,7 @@ func TestGetCachedImages(t *testing.T) {
 			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
 			"context":    resource.NewStringProperty("/twilight/sparkle/bin"),
 		})
-		actual := getCachedImages(imgInput, buildInput)
+		actual := marshalCachedImages(imgInput, buildInput)
 		assert.Equal(t, expected, actual)
 	})
 }

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -14,13 +14,11 @@ func TestSetRegistry(t *testing.T) {
 			Username: "pulumipus",
 			Password: "supersecret",
 		}
-		input := resource.PropertyValue{
-			resource.NewPropertyMapFromMap(map[string]interface{}{
-				"server":   "https://index.docker.io/v1/",
-				"username": "pulumipus",
-				"password": "supersecret",
-			}),
-		}
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"server":   resource.NewStringProperty("https://index.docker.io/v1/"),
+			"username": resource.NewStringProperty("pulumipus"),
+			"password": resource.NewStringProperty("supersecret"),
+		})
 
 		actual := setRegistry(input)
 		assert.Equal(t, expected, actual)
@@ -30,12 +28,10 @@ func TestSetRegistry(t *testing.T) {
 			Server:   "https://index.docker.io/v1/",
 			Username: "pulumipus",
 		}
-		input := resource.PropertyValue{
-			resource.NewPropertyMapFromMap(map[string]interface{}{
-				"server":   "https://index.docker.io/v1/",
-				"username": "pulumipus",
-			}),
-		}
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"server":   resource.NewStringProperty("https://index.docker.io/v1/"),
+			"username": resource.NewStringProperty("pulumipus"),
+		})
 
 		actual := setRegistry(input)
 		assert.Equal(t, expected, actual)
@@ -84,11 +80,9 @@ func TestMarshalBuild(t *testing.T) {
 			Args:       map[string]*string{},
 			Env:        map[string]string{},
 		}
-		input := resource.PropertyValue{
-			resource.NewPropertyMapFromMap(map[string]interface{}{
-				"dockerfile": "TheLastUnicorn",
-			}),
-		}
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
+		})
 		actual := marshalBuild(input)
 		assert.Equal(t, expected, actual)
 	})
@@ -100,12 +94,11 @@ func TestMarshalBuild(t *testing.T) {
 			Args:       map[string]*string{},
 			Env:        map[string]string{},
 		}
-		input := resource.PropertyValue{
-			resource.NewPropertyMapFromMap(map[string]interface{}{
-				"dockerfile": "TheLastUnicorn",
-				"context":    "/twilight/sparkle/bin",
-			}),
-		}
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
+			"context":    resource.NewStringProperty("/twilight/sparkle/bin"),
+		})
+
 		actual := marshalBuild(input)
 		assert.Equal(t, expected, actual)
 	})

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -51,8 +51,6 @@ func TestMarshalBuild(t *testing.T) {
 		expected := Build{
 			Context:    ".",
 			Dockerfile: "Dockerfile",
-			Args:       map[string]*string{},
-			Env:        map[string]string{},
 		}
 		input := resource.PropertyValue{
 			resource.NewPropertyMapFromMap(map[string]interface{}{}),
@@ -65,8 +63,6 @@ func TestMarshalBuild(t *testing.T) {
 		expected := Build{
 			Context:    "/twilight/sparkle/bin",
 			Dockerfile: "Dockerfile",
-			Args:       map[string]*string{},
-			Env:        map[string]string{},
 		}
 		input := resource.NewStringProperty("/twilight/sparkle/bin")
 		actual := marshalBuild(input)
@@ -77,8 +73,6 @@ func TestMarshalBuild(t *testing.T) {
 		expected := Build{
 			Context:    ".",
 			Dockerfile: "TheLastUnicorn",
-			Args:       map[string]*string{},
-			Env:        map[string]string{},
 		}
 		input := resource.NewObjectProperty(resource.PropertyMap{
 			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
@@ -91,8 +85,6 @@ func TestMarshalBuild(t *testing.T) {
 		expected := Build{
 			Context:    "/twilight/sparkle/bin",
 			Dockerfile: "TheLastUnicorn",
-			Args:       map[string]*string{},
-			Env:        map[string]string{},
 		}
 		input := resource.NewObjectProperty(resource.PropertyMap{
 			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
@@ -111,7 +103,6 @@ func TestMarshalBuild(t *testing.T) {
 			Args: map[string]*string{
 				"Swiftwind": &argval,
 			},
-			Env: map[string]string{},
 		}
 
 		input := resource.NewObjectProperty(resource.PropertyMap{
@@ -129,7 +120,6 @@ func TestMarshalBuild(t *testing.T) {
 		expected := Build{
 			Context:    ".",
 			Dockerfile: "Dockerfile",
-			Args:       map[string]*string{},
 			Env: map[string]string{
 				"Strawberry": "fruit",
 			},
@@ -167,7 +157,7 @@ func TestSetArgs(t *testing.T) {
 	})
 
 	t.Run("No args set", func(t *testing.T) {
-		expected := map[string]*string{}
+		expected := map[string]*string(nil)
 		input := resource.NewObjectProperty(resource.PropertyMap{})
 		actual := setArgs(input)
 		assert.Equal(t, expected, actual)
@@ -190,7 +180,7 @@ func TestSetEnvs(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 	t.Run("No environment variables", func(t *testing.T) {
-		expected := map[string]string{}
+		expected := map[string]string(nil)
 		input := resource.NewObjectProperty(resource.PropertyMap{})
 		actual := setEnvs(input)
 		assert.Equal(t, expected, actual)

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -135,6 +135,52 @@ func TestMarshalBuild(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
+	t.Run("Sets Extra Options", func(t *testing.T) {
+		expected := Build{
+			Context:      ".",
+			Dockerfile:   "Dockerfile",
+			ExtraOptions: []string{"cat", "dog", "pot-bellied pig"},
+		}
+
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"extraOptions": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("cat"),
+				resource.NewStringProperty("dog"),
+				resource.NewStringProperty("pot-bellied pig"),
+			}),
+		})
+
+		actual := marshalBuild(input)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("Does Not Set Extra Options on Empty Input", func(t *testing.T) {
+		expected := Build{
+			Context:    ".",
+			Dockerfile: "Dockerfile",
+		}
+
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"extraOptions": resource.NewArrayProperty([]resource.PropertyValue{}),
+		})
+
+		actual := marshalBuild(input)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Sets Target", func(t *testing.T) {
+		expected := Build{
+			Context:    ".",
+			Dockerfile: "Dockerfile",
+			Target:     "bullseye",
+		}
+
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"target": resource.NewStringProperty("bullseye"),
+		})
+
+		actual := marshalBuild(input)
+		assert.Equal(t, expected, actual)
+	})
 }
 
 func TestSetArgs(t *testing.T) {
@@ -156,7 +202,7 @@ func TestSetArgs(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("No args set", func(t *testing.T) {
+	t.Run("Returns nil when no args set", func(t *testing.T) {
 		expected := map[string]*string(nil)
 		input := resource.NewObjectProperty(resource.PropertyMap{})
 		actual := setArgs(input)
@@ -179,7 +225,7 @@ func TestSetEnvs(t *testing.T) {
 		actual := setEnvs(input)
 		assert.Equal(t, expected, actual)
 	})
-	t.Run("No environment variables", func(t *testing.T) {
+	t.Run("Returns nil when no environment variables set", func(t *testing.T) {
 		expected := map[string]string(nil)
 		input := resource.NewObjectProperty(resource.PropertyMap{})
 		actual := setEnvs(input)
@@ -251,3 +297,4 @@ func TestGetCachedImages(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 }
+

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -42,9 +42,72 @@ func TestSetRegistry(t *testing.T) {
 	testRegistryIncomplete := setRegistry(testRegistryIncompleteInput)
 	testRegistryNil := setRegistry(testRegistryNilInput)
 
-	assert.Equal(t, testRegistryValid, expectedRegistry)
-	assert.NotEqual(t, testRegistryIncomplete, expectedRegistry)
-	assert.Equal(t, testRegistryIncomplete, expectedRegistryIncomplete)
-	assert.Equal(t, testRegistryNil, expectedRegistryNil)
+	assert.Equal(t, expectedRegistry, testRegistryValid)
+	assert.NotEqual(t, expectedRegistry, testRegistryIncomplete)
+	assert.Equal(t, expectedRegistryIncomplete, testRegistryIncomplete)
+	assert.Equal(t, expectedRegistryNil, testRegistryNil)
+
+}
+
+func TestMarshalBuild(t *testing.T) {
+
+	t.Run("Default Build on empty input", func(t *testing.T) {
+		expected := Build{
+			Context:    ".",
+			Dockerfile: "Dockerfile",
+			Args:       map[string]*string{},
+			Env:        map[string]string{},
+		}
+		input := resource.PropertyValue{
+			resource.NewPropertyMapFromMap(map[string]interface{}{}),
+		}
+		actual := marshalBuild(input)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("String input Build", func(t *testing.T) {
+		expected := Build{
+			Context:    "/twilight/sparkle/bin",
+			Dockerfile: "Dockerfile",
+			Args:       map[string]*string{},
+			Env:        map[string]string{},
+		}
+		input := resource.NewStringProperty("/twilight/sparkle/bin")
+		actual := marshalBuild(input)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("Custom Dockerfile with default context", func(t *testing.T) {
+		expected := Build{
+			Context:    ".",
+			Dockerfile: "TheLastUnicorn",
+			Args:       map[string]*string{},
+			Env:        map[string]string{},
+		}
+		input := resource.PropertyValue{
+			resource.NewPropertyMapFromMap(map[string]interface{}{
+				"dockerfile": "TheLastUnicorn",
+			}),
+		}
+		actual := marshalBuild(input)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("Custom Dockerfile with custom context", func(t *testing.T) {
+		expected := Build{
+			Context:    "/twilight/sparkle/bin",
+			Dockerfile: "TheLastUnicorn",
+			Args:       map[string]*string{},
+			Env:        map[string]string{},
+		}
+		input := resource.PropertyValue{
+			resource.NewPropertyMapFromMap(map[string]interface{}{
+				"dockerfile": "TheLastUnicorn",
+				"context":    "/twilight/sparkle/bin",
+			}),
+		}
+		actual := marshalBuild(input)
+		assert.Equal(t, expected, actual)
+	})
 
 }

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -110,4 +110,84 @@ func TestMarshalBuild(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
+	t.Run("Setting Args", func(t *testing.T) {
+		argval := "Alicorn"
+		expected := Build{
+			Context:    ".",
+			Dockerfile: "Dockerfile",
+			Args: map[string]*string{
+				"Swiftwind": &argval,
+			},
+			Env: map[string]string{},
+		}
+
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"args": resource.NewObjectProperty(resource.PropertyMap{
+				"Swiftwind": resource.NewStringProperty("Alicorn"),
+			}),
+		})
+
+		actual := marshalBuild(input)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("Setting Env", func(t *testing.T) {
+
+		expected := Build{
+			Context:    ".",
+			Dockerfile: "Dockerfile",
+			Args:       map[string]*string{},
+			Env: map[string]string{
+				"Strawberry": "fruit",
+			},
+		}
+
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"env": resource.NewObjectProperty(resource.PropertyMap{
+				"Strawberry": resource.NewStringProperty("fruit"),
+			}),
+		})
+
+		actual := marshalBuild(input)
+		assert.Equal(t, expected, actual)
+	})
+
+}
+
+func TestSetArgs(t *testing.T) {
+	t.Run("Set any args", func(t *testing.T) {
+		a := "Alicorn"
+		p := "Pegasus"
+		tl := "Unicorn"
+		expected := map[string]*string{
+			"Swiftwind": &a,
+			"Fledge":    &p,
+			"The Last":  &tl,
+		}
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"Swiftwind": resource.NewStringProperty("Alicorn"),
+			"Fledge":    resource.NewStringProperty("Pegasus"),
+			"The Last":  resource.NewStringProperty("Unicorn"),
+		})
+		actual := setArgs(input)
+		assert.Equal(t, expected, actual)
+	})
+}
+
+func TestSetEnvs(t *testing.T) {
+	t.Run("Set any environment variables", func(t *testing.T) {
+
+		expected := map[string]string{
+			"Strawberry": "fruit",
+			"Carrot":     "veggie",
+			"Docker":     "a bit of a mess tbh",
+		}
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"Strawberry": resource.NewStringProperty("fruit"),
+			"Carrot":     resource.NewStringProperty("veggie"),
+			"Docker":     resource.NewStringProperty("a bit of a mess tbh"),
+		})
+		actual := setEnvs(input)
+		assert.Equal(t, expected, actual)
+	})
 }


### PR DESCRIPTION
This PR cleans up the input verification for Image and adds unit tests.
There are a few minor code changes mostly as a result of adding test cases.

Fixes #420

- refactor test case declaration
- Add tests for setRegistry. Harden setRegistry against nil interface values.
- Add first pass of marshalBuild tests
- Separate getting args and env into helper functions. Add basic test coverage for both
- Refactor Registry tests into suite
- clean up test case declaration for registry
- Add TestGetCachedImages
- Do not set empty maps for Args and Env
- Test ExtraOptions
