### PR TITLE
Ensure skipPush defaults to true

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -53,7 +53,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		return "", nil, err
 	}
 
-	reg := setRegistry(inputs["registry"])
+	reg := marshalRegistry(inputs["registry"])
 	skipPush := marshalSkipPush(inputs["skipPush"])
 	// read in values to Image
 	img := Image{
@@ -297,7 +297,7 @@ func marshalCachedImages(img Image, b resource.PropertyValue) []string {
 	return cacheImages
 }
 
-func setRegistry(r resource.PropertyValue) Registry {
+func marshalRegistry(r resource.PropertyValue) Registry {
 	var reg Registry
 	if !r.IsNull() {
 		if !r.ObjectValue()["server"].IsNull() {

--- a/provider/image.go
+++ b/provider/image.go
@@ -54,10 +54,11 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 	}
 
 	reg := setRegistry(inputs["registry"])
+	skipPush := marshalSkipPush(inputs["skipPush"])
 	// read in values to Image
 	img := Image{
 		Name:     inputs["imageName"].StringValue(),
-		SkipPush: inputs["skipPush"].BoolValue(),
+		SkipPush: skipPush,
 		Registry: reg,
 	}
 
@@ -360,4 +361,16 @@ func marshalBuilder(builder resource.PropertyValue) (types.BuilderVersion, error
 		// when version isn't set, we return an error
 		return version, errors.Errorf("Invalid Docker Builder version")
 	}
+}
+
+func marshalSkipPush(sp resource.PropertyValue) bool {
+	if sp.IsNull() {
+		// defaults to false
+		return false
+	}
+	if sp.BoolValue() == true {
+		// override default
+		return true
+	}
+	return false
 }

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -378,3 +378,27 @@ func TestMarshalBuilder(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestMarshalSkipPush(t *testing.T) {
+	t.Run("Test SkipPush defaults to false", func(t *testing.T) {
+		expected := false
+		input := resource.NewPropertyValue(nil)
+		actual := marshalSkipPush(input)
+		assert.Equal(t, expected, actual)
+
+	})
+	t.Run("Test SkipPush returns true if set to true", func(t *testing.T) {
+		expected := true
+		input := resource.NewBoolProperty(true)
+
+		actual := marshalSkipPush(input)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Test SkipPush returns false if set to false", func(t *testing.T) {
+		expected := false
+		input := resource.NewBoolProperty(false)
+
+		actual := marshalSkipPush(input)
+		assert.Equal(t, expected, actual)
+	})
+}

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -21,7 +21,7 @@ func TestSetRegistry(t *testing.T) {
 			"password": resource.NewStringProperty("supersecret"),
 		})
 
-		actual := setRegistry(input)
+		actual := marshalRegistry(input)
 		assert.Equal(t, expected, actual)
 	})
 	t.Run("Incomplete Registry sets all available fields", func(t *testing.T) {
@@ -34,14 +34,14 @@ func TestSetRegistry(t *testing.T) {
 			"username": resource.NewStringProperty("pulumipus"),
 		})
 
-		actual := setRegistry(input)
+		actual := marshalRegistry(input)
 		assert.Equal(t, expected, actual)
 	})
 
 	t.Run("Registry can be nil", func(t *testing.T) {
 		expected := Registry{}
 		input := resource.PropertyValue{}
-		actual := setRegistry(input)
+		actual := marshalRegistry(input)
 		assert.Equal(t, expected, actual)
 	})
 }


### PR DESCRIPTION
When using this provider with yaml, the default `skipPush: true` was not picked up and the provider panic()ed.
This PR explicitly ensures the value of `skipPush` is always true, unless set to false in the Pulumi program.
Adds tests.
A minor unrelated change gives a more meaningful name to the registry marshalling function. 

- Explicitly set skipPush default to true
- rename setRegistry to marshalRegistry
