### PR TITLE
Add code to generate example code from YAML for registry examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
 
+examples:
+	cd provider/pkg/gen/examples/ && go run generate.go ./yaml ./
+
 help: 
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
 	sed "s/\(.\+\):\s*\(.*\) #\s*\(.*\)/`printf "\033[93m"`\1`printf "\033[0m"`	\3 [\2]/" | \
@@ -110,4 +113,4 @@ tfgen: install_plugins
 bin/pulumi-java-gen: 
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks examples install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen

--- a/provider/pkg/gen/examples/generate.go
+++ b/provider/pkg/gen/examples/generate.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"gopkg.in/yaml.v3"
+)
+
+//go:generate go run generate.go yaml .
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Fprintf(os.Stdout, "Usage: %s <yaml source dir path> <markdown destination path>\n", os.Args[0])
+		os.Exit(1)
+	}
+	yamlPath := os.Args[1]
+	mdPath := os.Args[2]
+
+	if !filepath.IsAbs(yamlPath) {
+		cwd, err := os.Getwd()
+		contract.AssertNoError(err)
+		yamlPath = filepath.Join(cwd, yamlPath)
+	}
+
+	finfo, err := os.Lstat(mdPath)
+	if err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(mdPath, 0600); err != nil {
+			panic(err)
+		}
+	}
+
+	if !finfo.IsDir() {
+		fmt.Fprintf(os.Stderr, "Expect markdown destination %q to be a directory\n", mdPath)
+		os.Exit(1)
+	}
+
+	yamls, err := os.ReadDir(yamlPath)
+	if err != nil {
+		panic(err)
+	}
+	for _, yamlFile := range yamls {
+		if err := processYaml(filepath.Join(yamlPath, yamlFile.Name()), mdPath); err != nil {
+			fmt.Fprintf(os.Stderr, "%+v", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func markdownExamples(examples []string) string {
+	s := "{{% examples %}}\n## Example Usage\n"
+	for _, example := range examples {
+		s += example
+	}
+	s += "{{% /examples %}}\n"
+	return s
+}
+
+func markdownExample(description string,
+	typescript string,
+	python string,
+	csharp string,
+	golang string,
+	yaml string) string {
+
+	return fmt.Sprintf("{{%% example %%}}\n### %s\n\n"+
+		"```typescript\n%s```\n"+
+		"```python\n%s```\n"+
+		"```csharp\n%s```\n"+
+		"```go\n%s```\n"+
+		"```yaml\n%s```\n"+
+		"{{%% /example %%}}\n",
+		description, typescript, python, csharp, golang, yaml)
+}
+
+func processYaml(path string, mdDir string) error {
+	yamlFile, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	base := filepath.Base(path)
+	md := strings.NewReplacer(".yaml", ".md", ".yml", ".md").Replace(base)
+
+	defer contract.IgnoreClose(yamlFile)
+	decoder := yaml.NewDecoder(yamlFile)
+	exampleStrings := []string{}
+	for {
+		example := map[string]interface{}{}
+		err := decoder.Decode(&example)
+		if err == io.EOF {
+			break
+		}
+
+		description := example["description"].(string)
+		fmt.Fprintf(os.Stdout, "Processing %s\n", description)
+		dir, err := ioutil.TempDir("", "")
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			contract.IgnoreError(os.RemoveAll(dir))
+		}()
+
+		fmt.Fprintf(os.Stderr, "New dir: %q\n", dir)
+
+		src, err := os.OpenFile(filepath.Join(dir, "Pulumi.yaml"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+		if err != nil {
+			return err
+		}
+
+		if err = yaml.NewEncoder(src).Encode(example); err != nil {
+			return err
+		}
+		contract.AssertNoError(src.Close())
+
+		cmd := exec.Command("pulumi", "convert", "--language", "typescript", "--out",
+			filepath.Join(dir, "example-nodejs"), "--generate-only")
+		fmt.Println("RAN COMMAND")
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		fmt.Println(dir)
+		cmd.Dir = dir
+		if err = cmd.Run(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "convert nodejs failed, ignoring: %+v", err)
+		}
+		content, err := os.ReadFile(filepath.Join(dir, "example-nodejs", "index.ts"))
+		if err != nil {
+			return err
+		}
+		fmt.Println("NODEJS CONTENT:", string(content))
+		typescript := string(content)
+
+		cmd = exec.Command("pulumi", "convert", "--language", "python", "--out",
+			filepath.Join(dir, "example-py"), "--generate-only")
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "convert python failed, ignoring: %+v", err)
+		}
+		content, err = ioutil.ReadFile(filepath.Join(dir, "example-py", "__main__.py"))
+		if err != nil {
+			return err
+		}
+		fmt.Println("PYTHON CONTENT:", string(content))
+		python := string(content)
+
+		cmd = exec.Command("pulumi", "convert", "--language", "csharp", "--out",
+			filepath.Join(dir, "example-dotnet"), "--generate-only")
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		cmd.Dir = dir
+		if err = cmd.Run(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "convert go failed, ignoring: %+v", err)
+		}
+		content, err = ioutil.ReadFile(filepath.Join(dir, "example-dotnet", "Program.cs"))
+		if err != nil {
+			return err
+		}
+		fmt.Println("see sharp CONTENT:", string(content))
+		csharp := string(content)
+
+		cmd = exec.Command("pulumi", "convert", "--language", "go", "--out",
+			filepath.Join(dir, "example-go"), "--generate-only")
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		cmd.Dir = dir
+		if err = cmd.Run(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "convert go failed, ignoring: %+v", err)
+		}
+		content, err = ioutil.ReadFile(filepath.Join(dir, "example-go", "main.go"))
+		if err != nil {
+			return err
+		}
+		fmt.Println("Go CONTENT:", string(content))
+		golang := string(content)
+
+		// TODO add java when convert supports it.
+
+		content, err = ioutil.ReadFile(filepath.Join(dir, "Pulumi.yaml"))
+		if err != nil {
+			return err
+		}
+		yaml := string(content)
+
+		exampleStrings = append(exampleStrings, markdownExample(description, typescript, python, csharp, golang, yaml))
+	}
+	contract.AssertNoError(err)
+	fmt.Fprintf(os.Stdout, "Writing %s\n", filepath.Join(mdDir, md))
+	f, err := os.OpenFile(filepath.Join(mdDir, md), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(f)
+	_, err = f.Write([]byte(markdownExamples(exampleStrings)))
+	contract.AssertNoError(err)
+	return nil
+}

--- a/provider/pkg/gen/examples/image.md
+++ b/provider/pkg/gen/examples/image.md
@@ -1,17 +1,17 @@
 {{% examples %}}
 ## Example Usage
 {{% example %}}
-### A minimal Pulumi YAML program
+### A Docker image build
 
 ```typescript
 import * as pulumi from "@pulumi/pulumi";
 
-export const imageName = guinsImage.imageName;
+export const imageName = demoImage.imageName;
 ```
 ```python
 import pulumi
 
-pulumi.export("imageName", guins_image["imageName"])
+pulumi.export("imageName", demo_image["imageName"])
 ```
 ```csharp
 using System.Collections.Generic;
@@ -21,7 +21,7 @@ return await Deployment.RunAsync(() =>
 {
     return new Dictionary<string, object?>
     {
-        ["imageName"] = guinsImage.ImageName,
+        ["imageName"] = demoImage.ImageName,
     };
 });
 
@@ -35,24 +35,24 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		ctx.Export("imageName", guinsImage.ImageName)
+		ctx.Export("imageName", demoImage.ImageName)
 		return nil
 	})
 }
 ```
 ```yaml
 config: {}
-description: A minimal Pulumi YAML program
+description: A Docker image build
 name: image-yaml
 outputs:
-    imageName: ${guins-image.imageName}
+    imageName: ${demo-image.imageName}
 resources:
-    guins-image:
+    demo-image:
         properties:
             build:
                 context: .
                 dockerfile: Dockerfile
-            imageName: gsaenger/test-yaml:tag1
+            imageName: username/image:tag1
             skipPush: true
         type: docker:Image
 runtime: yaml

--- a/provider/pkg/gen/examples/image.md
+++ b/provider/pkg/gen/examples/image.md
@@ -1,0 +1,62 @@
+{{% examples %}}
+## Example Usage
+{{% example %}}
+### A minimal Pulumi YAML program
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+
+export const imageName = guinsImage.imageName;
+```
+```python
+import pulumi
+
+pulumi.export("imageName", guins_image["imageName"])
+```
+```csharp
+using System.Collections.Generic;
+using Pulumi;
+
+return await Deployment.RunAsync(() => 
+{
+    return new Dictionary<string, object?>
+    {
+        ["imageName"] = guinsImage.ImageName,
+    };
+});
+
+```
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		ctx.Export("imageName", guinsImage.ImageName)
+		return nil
+	})
+}
+```
+```yaml
+config: {}
+description: A minimal Pulumi YAML program
+name: image-yaml
+outputs:
+    imageName: ${guins-image.imageName}
+resources:
+    guins-image:
+        properties:
+            build:
+                context: .
+                dockerfile: Dockerfile
+            imageName: gsaenger/test-yaml:tag1
+            skipPush: true
+        type: docker:Image
+runtime: yaml
+variables: {}
+```
+{{% /example %}}
+{{% /examples %}}

--- a/provider/pkg/gen/examples/yaml/image.yaml
+++ b/provider/pkg/gen/examples/yaml/image.yaml
@@ -1,16 +1,16 @@
 name: image-yaml
-description: A minimal Pulumi YAML program
+description: A Docker image build
 runtime: yaml
 config: {}
 variables: {}
 resources:
-  guins-image:
+  demo-image:
     type: docker:Image
     properties:
-      imageName: gsaenger/test-yaml:tag1
+      imageName: username/image:tag1
       skipPush: true
       build:
         dockerfile: Dockerfile
         context: .
 outputs:
-  imageName: ${guins-image.imageName}
+  imageName: ${demo-image.imageName}

--- a/provider/pkg/gen/examples/yaml/image.yaml
+++ b/provider/pkg/gen/examples/yaml/image.yaml
@@ -1,0 +1,16 @@
+name: image-yaml
+description: A minimal Pulumi YAML program
+runtime: yaml
+config: {}
+variables: {}
+resources:
+  guins-image:
+    type: docker:Image
+    properties:
+      imageName: gsaenger/test-yaml:tag1
+      skipPush: true
+      build:
+        dockerfile: Dockerfile
+        context: .
+outputs:
+  imageName: ${guins-image.imageName}


### PR DESCRIPTION
Using https://github.com/pulumi/pulumi-kubernetes/pull/1999 as inspiration, this PR adds a way to generate example files for the registry.

What is missing here is how the registry will pick up this documentation
Also blocked by https://github.com/pulumi/pulumi-yaml/issues/422.

Fixes #406

- Add code to  generate documentation to provider package
- Add examplegen as a Makefile step
