### PR TITLE
Ensure forward build compatibility for resource provider

### DIFF
--- a/provider/hybrid.go
+++ b/provider/hybrid.go
@@ -19,6 +19,8 @@ import (
 // gets handled by which provider via if/else logic.
 
 type dockerHybridProvider struct {
+	rpc.UnimplementedResourceProviderServer
+
 	schemaBytes     []byte
 	version         string
 	bridgedProvider rpc.ResourceProviderServer

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -16,6 +16,8 @@ import (
 )
 
 type dockerNativeProvider struct {
+	rpc.UnimplementedResourceProviderServer
+
 	host        *provider.HostClient
 	name        string
 	version     string


### PR DESCRIPTION
See: https://github.com/pulumi/pulumi/issues/11616

This change ensures the Docker provider is source-code forward compatible with future changes to the gRPC interfaces for providers upstream. This reduces the likelihood that source code changes are needed when updating to new Pulumi SDK/PKG versions.

The same change is being made in the bridge and other providers to ensure that CI systems can reliably build and test new versions of the core Pulumi engine against providers.