### PR TITLE
Process and display build and push logs

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -77,7 +77,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		return "", nil, err
 	}
 
-	err = p.host.Log(ctx, "info", urn, "Building the image")
+	err = p.host.LogStatus(ctx, "info", urn, "Building the image")
 
 	if err != nil {
 		return "", nil, err
@@ -106,10 +106,10 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 	}
 
 	defer imgBuildResp.Body.Close()
-	// Print build logs to terminal
+	// Print build logs to `Info` progress report
 	scanner := bufio.NewScanner(imgBuildResp.Body)
 	for scanner.Scan() {
-		err := p.host.Log(ctx, "info", urn, scanner.Text())
+		err := p.host.LogStatus(ctx, "info", urn, scanner.Text())
 		if err != nil {
 			return "", nil, err
 		}
@@ -130,7 +130,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		return img.Name, pbstruct, err
 	}
 
-	err = p.host.Log(ctx, "info", urn, "Pushing Image to the registry")
+	err = p.host.LogStatus(ctx, "info", urn, "Pushing Image to the registry")
 
 	if err != nil {
 		return "", nil, err
@@ -161,7 +161,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 
 	defer pushOutput.Close()
 
-	// Print push logs to terminal
+	// Print push logs to `Info` progress report
 	pushScanner := bufio.NewScanner(pushOutput)
 	for pushScanner.Scan() {
 		msg := pushScanner.Text()
@@ -179,7 +179,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 					info = jsmsg.Status
 
 				}
-				err := p.host.Log(ctx, "info", urn, info)
+				err := p.host.LogStatus(ctx, "info", urn, info)
 				if err != nil {
 					return "", nil, err
 				}

--- a/provider/image.go
+++ b/provider/image.go
@@ -384,6 +384,10 @@ func processLogLine(msg string) (string, error) {
 	} else {
 		info = jm.Status
 	}
-
+	if jm.Aux != nil {
+		infoBytes, _ := json.Marshal(jm.Aux)
+		// because this is unstructured JSON we print out the whole object.
+		info = string(infoBytes)
+	}
 	return info, nil
 }


### PR DESCRIPTION
This PR leverages Pulumi's `host.LogStatus` function to display Docker image logs "ephemerally", i.e. in the "Info" status column on the Pulumi terminal output.
Additionally, this change uses Docker's [`JSONMessage` package](https://pkg.go.dev/github.com/docker/docker/pkg/jsonmessage@v20.10.21+incompatible) to parse the information given by the Docker build process.
Using this package allows us to uniformly process all logs sent by Docker and have reasonable baseline expectations for informational fields.
The local implementation leans strongly on the logic in `jsonmessage.Display` to extract all relevant information.
The result is that the user can watch Docker build logs in the Pulumi Info box.
 
Fixes https://github.com/pulumi/pulumi-docker/issues/441.


- Move host.Log to host.LogStatus which displays logs ephemerally
- fully leverage JSONMessage to process all the statuses
- also add Aux information
