### PR TITLE
Use Docker credentials file to log in to registry

### DIFF
--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -3161,9 +3161,7 @@
             },
             "type": "object",
             "required": [
-                "server",
-                "username",
-                "password"
+                "server"
             ]
         }
     },

--- a/provider/image.go
+++ b/provider/image.go
@@ -187,13 +187,15 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 	} else {
 		// send warning if user is attempting to use in-program credentials
 		if img.Registry.Username == "" && img.Registry.Password != "" {
-			err = p.host.LogStatus(ctx, "warning", urn, "username was not set, although password was; using host credentials file")
+			msg := "username was not set, although password was; using host credentials file"
+			err = p.host.LogStatus(ctx, "warning", urn, msg)
 			if err != nil {
 				return "", nil, err
 			}
 		}
 		if img.Registry.Password == "" && img.Registry.Username != "" {
-			err = p.host.LogStatus(ctx, "warning", urn, "password was not set, although username was; using host credentials file")
+			msg := "password was not set, although username was; using host credentials file"
+			err = p.host.LogStatus(ctx, "warning", urn, msg)
 			if err != nil {
 				return "", nil, err
 			}

--- a/provider/image.go
+++ b/provider/image.go
@@ -187,10 +187,16 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 	} else {
 		// send warning if user is attempting to use in-program credentials
 		if img.Registry.Username == "" && img.Registry.Password != "" {
-			p.host.LogStatus(ctx, "warning", urn, "username was not set, although password was; using host credentials file")
+			err = p.host.LogStatus(ctx, "warning", urn, "username was not set, although password was; using host credentials file")
+			if err != nil {
+				return "", nil, err
+			}
 		}
 		if img.Registry.Password == "" && img.Registry.Username != "" {
-			p.host.LogStatus(ctx, "warning", urn, "password was not set, although username was; using host credentials file")
+			err = p.host.LogStatus(ctx, "warning", urn, "password was not set, although username was; using host credentials file")
+			if err != nil {
+				return "", nil, err
+			}
 		}
 		// we push to the server declared in the program, using our auth configs from image build.
 		// if the program does not have a server declared, we will let the docker client error

--- a/provider/image.go
+++ b/provider/image.go
@@ -185,6 +185,13 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		pushAuthConfig.Password = img.Registry.Password
 		pushAuthConfig.ServerAddress = img.Registry.Server
 	} else {
+		// send warning if user is attempting to use in-program credentials
+		if img.Registry.Username == "" && img.Registry.Password != "" {
+			p.host.LogStatus(ctx, "warning", urn, "username was not set, although password was; using host credentials file")
+		}
+		if img.Registry.Password == "" && img.Registry.Username != "" {
+			p.host.LogStatus(ctx, "warning", urn, "password was not set, although username was; using host credentials file")
+		}
 		// we push to the server declared in the program, using our auth configs from image build.
 		// if the program does not have a server declared, we will let the docker client error
 		pushAuthConfig = authConfigs[img.Registry.Server]
@@ -215,7 +222,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		if err != nil {
 			return "", nil, err
 		}
-		err = p.host.Log(ctx, "info", urn, info)
+		err = p.host.LogStatus(ctx, "info", urn, info)
 		if err != nil {
 			return "", nil, err
 		}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -134,7 +134,7 @@ func Provider() tfbridge.ProviderInfo {
 							Secret:      true,
 						},
 					},
-					Required: []string{"server", "username", "password"},
+					Required: []string{"server"},
 				},
 			},
 			dockerResource(dockerMod, "DockerBuild").String(): {

--- a/sdk/dotnet/Inputs/RegistryArgs.cs
+++ b/sdk/dotnet/Inputs/RegistryArgs.cs
@@ -15,7 +15,7 @@ namespace Pulumi.Docker.Inputs
     /// </summary>
     public sealed class RegistryArgs : global::Pulumi.ResourceArgs
     {
-        [Input("password", required: true)]
+        [Input("password")]
         private Input<string>? _password;
 
         /// <summary>
@@ -40,8 +40,8 @@ namespace Pulumi.Docker.Inputs
         /// <summary>
         /// The username to authenticate to the registry
         /// </summary>
-        [Input("username", required: true)]
-        public Input<string> Username { get; set; } = null!;
+        [Input("username")]
+        public Input<string>? Username { get; set; }
 
         public RegistryArgs()
         {

--- a/sdk/go/docker/pulumiTypes.go
+++ b/sdk/go/docker/pulumiTypes.go
@@ -9860,11 +9860,11 @@ func (o GetNetworkIpamConfigArrayOutput) Index(i pulumi.IntInput) GetNetworkIpam
 // Describes a Docker container registry
 type Registry struct {
 	// The password to authenticate to the registry
-	Password string `pulumi:"password"`
+	Password *string `pulumi:"password"`
 	// The URL of the Docker registry server
 	Server string `pulumi:"server"`
 	// The username to authenticate to the registry
-	Username string `pulumi:"username"`
+	Username *string `pulumi:"username"`
 }
 
 // RegistryInput is an input type that accepts RegistryArgs and RegistryOutput values.
@@ -9881,11 +9881,11 @@ type RegistryInput interface {
 // Describes a Docker container registry
 type RegistryArgs struct {
 	// The password to authenticate to the registry
-	Password pulumi.StringInput `pulumi:"password"`
+	Password pulumi.StringPtrInput `pulumi:"password"`
 	// The URL of the Docker registry server
 	Server pulumi.StringInput `pulumi:"server"`
 	// The username to authenticate to the registry
-	Username pulumi.StringInput `pulumi:"username"`
+	Username pulumi.StringPtrInput `pulumi:"username"`
 }
 
 func (RegistryArgs) ElementType() reflect.Type {
@@ -9967,8 +9967,8 @@ func (o RegistryOutput) ToRegistryPtrOutputWithContext(ctx context.Context) Regi
 }
 
 // The password to authenticate to the registry
-func (o RegistryOutput) Password() pulumi.StringOutput {
-	return o.ApplyT(func(v Registry) string { return v.Password }).(pulumi.StringOutput)
+func (o RegistryOutput) Password() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Registry) *string { return v.Password }).(pulumi.StringPtrOutput)
 }
 
 // The URL of the Docker registry server
@@ -9977,8 +9977,8 @@ func (o RegistryOutput) Server() pulumi.StringOutput {
 }
 
 // The username to authenticate to the registry
-func (o RegistryOutput) Username() pulumi.StringOutput {
-	return o.ApplyT(func(v Registry) string { return v.Username }).(pulumi.StringOutput)
+func (o RegistryOutput) Username() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Registry) *string { return v.Username }).(pulumi.StringPtrOutput)
 }
 
 type RegistryPtrOutput struct{ *pulumi.OutputState }
@@ -10011,7 +10011,7 @@ func (o RegistryPtrOutput) Password() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return &v.Password
+		return v.Password
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -10031,7 +10031,7 @@ func (o RegistryPtrOutput) Username() pulumi.StringPtrOutput {
 		if v == nil {
 			return nil
 		}
-		return &v.Username
+		return v.Username
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/java/src/main/java/com/pulumi/docker/inputs/RegistryArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/inputs/RegistryArgs.java
@@ -7,6 +7,8 @@ import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import java.lang.String;
 import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 
 /**
@@ -21,15 +23,15 @@ public final class RegistryArgs extends com.pulumi.resources.ResourceArgs {
      * The password to authenticate to the registry
      * 
      */
-    @Import(name="password", required=true)
-    private Output<String> password;
+    @Import(name="password")
+    private @Nullable Output<String> password;
 
     /**
      * @return The password to authenticate to the registry
      * 
      */
-    public Output<String> password() {
-        return this.password;
+    public Optional<Output<String>> password() {
+        return Optional.ofNullable(this.password);
     }
 
     /**
@@ -51,15 +53,15 @@ public final class RegistryArgs extends com.pulumi.resources.ResourceArgs {
      * The username to authenticate to the registry
      * 
      */
-    @Import(name="username", required=true)
-    private Output<String> username;
+    @Import(name="username")
+    private @Nullable Output<String> username;
 
     /**
      * @return The username to authenticate to the registry
      * 
      */
-    public Output<String> username() {
-        return this.username;
+    public Optional<Output<String>> username() {
+        return Optional.ofNullable(this.username);
     }
 
     private RegistryArgs() {}
@@ -94,7 +96,7 @@ public final class RegistryArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder password(Output<String> password) {
+        public Builder password(@Nullable Output<String> password) {
             $.password = password;
             return this;
         }
@@ -136,7 +138,7 @@ public final class RegistryArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder username(Output<String> username) {
+        public Builder username(@Nullable Output<String> username) {
             $.username = username;
             return this;
         }
@@ -152,9 +154,7 @@ public final class RegistryArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public RegistryArgs build() {
-            $.password = Objects.requireNonNull($.password, "expected parameter 'password' to be non-null");
             $.server = Objects.requireNonNull($.server, "expected parameter 'server' to be non-null");
-            $.username = Objects.requireNonNull($.username, "expected parameter 'username' to be non-null");
             return $;
         }
     }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -380,7 +380,7 @@ export interface Registry {
     /**
      * The password to authenticate to the registry
      */
-    password: pulumi.Input<string>;
+    password?: pulumi.Input<string>;
     /**
      * The URL of the Docker registry server
      */
@@ -388,7 +388,7 @@ export interface Registry {
     /**
      * The username to authenticate to the registry
      */
-    username: pulumi.Input<string>;
+    username?: pulumi.Input<string>;
 }
 
 export interface RegistryImageBuild {

--- a/sdk/python/pulumi_docker/_inputs.py
+++ b/sdk/python/pulumi_docker/_inputs.py
@@ -4196,30 +4196,20 @@ class DockerBuildArgs:
 @pulumi.input_type
 class RegistryArgs:
     def __init__(__self__, *,
-                 password: pulumi.Input[str],
                  server: pulumi.Input[str],
-                 username: pulumi.Input[str]):
+                 password: Optional[pulumi.Input[str]] = None,
+                 username: Optional[pulumi.Input[str]] = None):
         """
         Describes a Docker container registry
-        :param pulumi.Input[str] password: The password to authenticate to the registry
         :param pulumi.Input[str] server: The URL of the Docker registry server
+        :param pulumi.Input[str] password: The password to authenticate to the registry
         :param pulumi.Input[str] username: The username to authenticate to the registry
         """
-        pulumi.set(__self__, "password", password)
         pulumi.set(__self__, "server", server)
-        pulumi.set(__self__, "username", username)
-
-    @property
-    @pulumi.getter
-    def password(self) -> pulumi.Input[str]:
-        """
-        The password to authenticate to the registry
-        """
-        return pulumi.get(self, "password")
-
-    @password.setter
-    def password(self, value: pulumi.Input[str]):
-        pulumi.set(self, "password", value)
+        if password is not None:
+            pulumi.set(__self__, "password", password)
+        if username is not None:
+            pulumi.set(__self__, "username", username)
 
     @property
     @pulumi.getter
@@ -4235,14 +4225,26 @@ class RegistryArgs:
 
     @property
     @pulumi.getter
-    def username(self) -> pulumi.Input[str]:
+    def password(self) -> Optional[pulumi.Input[str]]:
+        """
+        The password to authenticate to the registry
+        """
+        return pulumi.get(self, "password")
+
+    @password.setter
+    def password(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "password", value)
+
+    @property
+    @pulumi.getter
+    def username(self) -> Optional[pulumi.Input[str]]:
         """
         The username to authenticate to the registry
         """
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: pulumi.Input[str]):
+    def username(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "username", value)
 
 


### PR DESCRIPTION
Fixes #442.

This PR includes a slight tweak to the schema, requiring only the `server` field of the `registry` type to be required when using `registry`.
SDKs were regenerated accordingly.
Adds new logic to use Docker config file credentials when username and passworkd are not provided via the Pulumi program.

- Do not make registry Username and Password required
- Enable use of  Docker configuration for push registry authentication
