### PR TITLE
Fix panic in Check function

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -128,7 +128,6 @@ func (p *dockerNativeProvider) Check(ctx context.Context, req *rpc.CheckRequest)
 	inputs["build"] = resource.NewObjectProperty(resource.PropertyMap{
 		"contextDigest": resource.NewStringProperty(contextDigest),
 	})
-	//inputs["build"].ObjectValue()["contextDigest"] = resource.NewStringProperty(contextDigest)
 
 	inputStruct, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{
 		KeepUnknowns: true,

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -125,9 +125,13 @@ func (p *dockerNativeProvider) Check(ctx context.Context, req *rpc.CheckRequest)
 	}
 
 	// add implicit resource to provider
-	inputs["build"] = resource.NewObjectProperty(resource.PropertyMap{
-		"contextDigest": resource.NewStringProperty(contextDigest),
-	})
+	if inputs["build"].IsNull() {
+		inputs["build"] = resource.NewObjectProperty(resource.PropertyMap{
+			"contextDigest": resource.NewStringProperty(contextDigest),
+		})
+	} else {
+		inputs["build"].ObjectValue()["contextDigest"] = resource.NewStringProperty(contextDigest)
+	}
 
 	inputStruct, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{
 		KeepUnknowns: true,

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -125,7 +125,10 @@ func (p *dockerNativeProvider) Check(ctx context.Context, req *rpc.CheckRequest)
 	}
 
 	// add implicit resource to provider
-	inputs["build"].ObjectValue()["contextDigest"] = resource.NewStringProperty(contextDigest)
+	inputs["build"] = resource.NewObjectProperty(resource.PropertyMap{
+		"contextDigest": resource.NewStringProperty(contextDigest),
+	})
+	//inputs["build"].ObjectValue()["contextDigest"] = resource.NewStringProperty(contextDigest)
 
 	inputStruct, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{
 		KeepUnknowns: true,


### PR DESCRIPTION
When the `build` field is unset entirely, the Check function was
panicking attempting to set the implicit `contextDigest` field.
This PR properly constructs the `inputs["build"]` field as a
`resource.NewObjectProperty`.
