### PR TITLE
Add Cache From feature

### DIFF
--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -3033,14 +3033,14 @@
             ]
         },
         "docker:index/cacheFrom:CacheFrom": {
-            "description": "Specifies information about where to obtain a cache",
+            "description": "Contains a list of images to reference when building using a cache",
             "properties": {
-                "stages": {
+                "images": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     },
-                    "description": "A list of cached build stages"
+                    "description": "Specifies cached images"
                 }
             },
             "type": "object"
@@ -3061,15 +3061,8 @@
                     "default": "BuilderBuildKit"
                 },
                 "cacheFrom": {
-                    "oneOf": [
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "$ref": "#/types/docker:index/cacheFrom:CacheFrom"
-                        }
-                    ],
-                    "description": "A cached image or list of build stages to use as build cache"
+                    "$ref": "#/types/docker:index/cacheFrom:CacheFrom",
+                    "description": "A list of images to use as build cache"
                 },
                 "context": {
                     "type": "string",

--- a/provider/image.go
+++ b/provider/image.go
@@ -111,9 +111,9 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		Dockerfile: img.Build.Dockerfile,
 		Tags:       []string{img.Name}, //this should build the image locally, sans registry info
 		Remove:     true,
-		//CacheFrom:  img.Build.CachedImages, // TODO: this needs a login, so needs to be handled differently.
-		BuildArgs: build.Args,
-		Version:   build.BuilderVersion,
+		CacheFrom:  img.Build.CachedImages,
+		BuildArgs:  build.Args,
+		Version:    build.BuilderVersion,
 
 		AuthConfigs: authConfigs,
 	}
@@ -519,16 +519,21 @@ func processLogLine(msg string) (string, error) {
 				info += "failed to parse aux message: " + err.Error()
 			}
 			for _, vertex := range resp.Vertexes {
-				info += fmt.Sprintf("layer: %+v\n", vertex.Digest)
+				info += fmt.Sprintf("digest: %+v\n", vertex.Digest)
+				info += fmt.Sprintf("%s\n", vertex.Name)
+				if vertex.Error != "" {
+					info += fmt.Sprintf("error: %s\n", vertex.Error)
+				}
 			}
 			for _, status := range resp.Statuses {
-				info += fmt.Sprintf("status: %s\n", status.GetID())
+				info += fmt.Sprintf("%s\n", status.GetID())
 			}
 			for _, log := range resp.Logs {
-				info += fmt.Sprintf("log: %+v\n", log.GetMsg())
+				info += fmt.Sprintf("%s\n", string(log.Msg))
+
 			}
 			for _, warn := range resp.Warnings {
-				info += fmt.Sprintf("warning: %+v\n", warn.GetShort())
+				info += fmt.Sprintf("%s\n", string(warn.Short))
 			}
 
 		} else {

--- a/provider/image.go
+++ b/provider/image.go
@@ -332,18 +332,10 @@ func marshalCachedImages(img Image, b resource.PropertyValue) []string {
 	if c.IsNull() {
 		return cacheImages
 	}
-	latest := img.Registry.Username + "/" + img.Name
-	// if we specify cacheFrom as True, we pull the latest build+push of our image implicitly, i.e. registry/image
-	if c.IsBool() {
-		useCache := c.BoolValue()
-		if useCache {
-			cacheImages = append(cacheImages, latest)
-		}
-		return cacheImages
-	}
+
 	// if we specify a list of stages, then we only pull those
 	cacheFrom := c.ObjectValue()
-	stages := cacheFrom["stages"].ArrayValue()
+	stages := cacheFrom["images"].ArrayValue()
 	for _, img := range stages {
 		stage := img.StringValue()
 		cacheImages = append(cacheImages, stage)

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -296,7 +296,7 @@ func TestMarshalCachedImages(t *testing.T) {
 			"context":    resource.NewStringProperty("/twilight/sparkle/bin"),
 
 			"cacheFrom": resource.NewObjectProperty(resource.PropertyMap{
-				"stages": resource.NewArrayProperty([]resource.PropertyValue{
+				"images": resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewStringProperty("apple"),
 					resource.NewStringProperty("banana"),
 					resource.NewStringProperty("cherry"),

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -152,16 +152,9 @@ func Provider() tfbridge.ProviderInfo {
 							Default:     "Dockerfile",
 						},
 						"cacheFrom": {
-							Description: "A cached image or list of build stages to use as build cache",
+							Description: "A list of images to use as build cache",
 							TypeSpec: schema.TypeSpec{
-								OneOf: []schema.TypeSpec{
-									{
-										Type: "boolean",
-									},
-									{
-										Ref: "#/types/docker:index/cacheFrom:CacheFrom",
-									},
-								},
+								Ref: "#/types/docker:index/cacheFrom:CacheFrom",
 							},
 						},
 						"env": {
@@ -211,10 +204,10 @@ func Provider() tfbridge.ProviderInfo {
 			dockerResource(dockerMod, "CacheFrom").String(): {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Type:        "object",
-					Description: "Specifies information about where to obtain a cache",
+					Description: "Contains a list of images to reference when building using a cache",
 					Properties: map[string]schema.PropertySpec{
-						"stages": {
-							Description: "A list of cached build stages",
+						"images": {
+							Description: "Specifies cached images",
 							TypeSpec: schema.TypeSpec{
 								Type: "array",
 								Items: &schema.TypeSpec{

--- a/sdk/dotnet/Inputs/CacheFromArgs.cs
+++ b/sdk/dotnet/Inputs/CacheFromArgs.cs
@@ -11,20 +11,20 @@ namespace Pulumi.Docker.Inputs
 {
 
     /// <summary>
-    /// Specifies information about where to obtain a cache
+    /// Contains a list of images to reference when building using a cache
     /// </summary>
     public sealed class CacheFromArgs : global::Pulumi.ResourceArgs
     {
-        [Input("stages")]
-        private InputList<string>? _stages;
+        [Input("images")]
+        private InputList<string>? _images;
 
         /// <summary>
-        /// A list of cached build stages
+        /// Specifies cached images
         /// </summary>
-        public InputList<string> Stages
+        public InputList<string> Images
         {
-            get => _stages ?? (_stages = new InputList<string>());
-            set => _stages = value;
+            get => _images ?? (_images = new InputList<string>());
+            set => _images = value;
         }
 
         public CacheFromArgs()

--- a/sdk/dotnet/Inputs/DockerBuildArgs.cs
+++ b/sdk/dotnet/Inputs/DockerBuildArgs.cs
@@ -34,10 +34,10 @@ namespace Pulumi.Docker.Inputs
         public Input<Pulumi.Docker.BuilderVersion>? BuilderVersion { get; set; }
 
         /// <summary>
-        /// A cached image or list of build stages to use as build cache
+        /// A list of images to use as build cache
         /// </summary>
         [Input("cacheFrom")]
-        public InputUnion<bool, Inputs.CacheFromArgs>? CacheFrom { get; set; }
+        public Input<Inputs.CacheFromArgs>? CacheFrom { get; set; }
 
         /// <summary>
         /// The path to the build context to use.

--- a/sdk/go/docker/pulumiTypes.go
+++ b/sdk/go/docker/pulumiTypes.go
@@ -9534,10 +9534,10 @@ func (o VolumeLabelArrayOutput) Index(i pulumi.IntInput) VolumeLabelOutput {
 	}).(VolumeLabelOutput)
 }
 
-// Specifies information about where to obtain a cache
+// Contains a list of images to reference when building using a cache
 type CacheFrom struct {
-	// A list of cached build stages
-	Stages []string `pulumi:"stages"`
+	// Specifies cached images
+	Images []string `pulumi:"images"`
 }
 
 // CacheFromInput is an input type that accepts CacheFromArgs and CacheFromOutput values.
@@ -9551,10 +9551,10 @@ type CacheFromInput interface {
 	ToCacheFromOutputWithContext(context.Context) CacheFromOutput
 }
 
-// Specifies information about where to obtain a cache
+// Contains a list of images to reference when building using a cache
 type CacheFromArgs struct {
-	// A list of cached build stages
-	Stages pulumi.StringArrayInput `pulumi:"stages"`
+	// Specifies cached images
+	Images pulumi.StringArrayInput `pulumi:"images"`
 }
 
 func (CacheFromArgs) ElementType() reflect.Type {
@@ -9569,7 +9569,48 @@ func (i CacheFromArgs) ToCacheFromOutputWithContext(ctx context.Context) CacheFr
 	return pulumi.ToOutputWithContext(ctx, i).(CacheFromOutput)
 }
 
-// Specifies information about where to obtain a cache
+func (i CacheFromArgs) ToCacheFromPtrOutput() CacheFromPtrOutput {
+	return i.ToCacheFromPtrOutputWithContext(context.Background())
+}
+
+func (i CacheFromArgs) ToCacheFromPtrOutputWithContext(ctx context.Context) CacheFromPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(CacheFromOutput).ToCacheFromPtrOutputWithContext(ctx)
+}
+
+// CacheFromPtrInput is an input type that accepts CacheFromArgs, CacheFromPtr and CacheFromPtrOutput values.
+// You can construct a concrete instance of `CacheFromPtrInput` via:
+//
+//	        CacheFromArgs{...}
+//
+//	or:
+//
+//	        nil
+type CacheFromPtrInput interface {
+	pulumi.Input
+
+	ToCacheFromPtrOutput() CacheFromPtrOutput
+	ToCacheFromPtrOutputWithContext(context.Context) CacheFromPtrOutput
+}
+
+type cacheFromPtrType CacheFromArgs
+
+func CacheFromPtr(v *CacheFromArgs) CacheFromPtrInput {
+	return (*cacheFromPtrType)(v)
+}
+
+func (*cacheFromPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**CacheFrom)(nil)).Elem()
+}
+
+func (i *cacheFromPtrType) ToCacheFromPtrOutput() CacheFromPtrOutput {
+	return i.ToCacheFromPtrOutputWithContext(context.Background())
+}
+
+func (i *cacheFromPtrType) ToCacheFromPtrOutputWithContext(ctx context.Context) CacheFromPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(CacheFromPtrOutput)
+}
+
+// Contains a list of images to reference when building using a cache
 type CacheFromOutput struct{ *pulumi.OutputState }
 
 func (CacheFromOutput) ElementType() reflect.Type {
@@ -9584,9 +9625,53 @@ func (o CacheFromOutput) ToCacheFromOutputWithContext(ctx context.Context) Cache
 	return o
 }
 
-// A list of cached build stages
-func (o CacheFromOutput) Stages() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v CacheFrom) []string { return v.Stages }).(pulumi.StringArrayOutput)
+func (o CacheFromOutput) ToCacheFromPtrOutput() CacheFromPtrOutput {
+	return o.ToCacheFromPtrOutputWithContext(context.Background())
+}
+
+func (o CacheFromOutput) ToCacheFromPtrOutputWithContext(ctx context.Context) CacheFromPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v CacheFrom) *CacheFrom {
+		return &v
+	}).(CacheFromPtrOutput)
+}
+
+// Specifies cached images
+func (o CacheFromOutput) Images() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v CacheFrom) []string { return v.Images }).(pulumi.StringArrayOutput)
+}
+
+type CacheFromPtrOutput struct{ *pulumi.OutputState }
+
+func (CacheFromPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**CacheFrom)(nil)).Elem()
+}
+
+func (o CacheFromPtrOutput) ToCacheFromPtrOutput() CacheFromPtrOutput {
+	return o
+}
+
+func (o CacheFromPtrOutput) ToCacheFromPtrOutputWithContext(ctx context.Context) CacheFromPtrOutput {
+	return o
+}
+
+func (o CacheFromPtrOutput) Elem() CacheFromOutput {
+	return o.ApplyT(func(v *CacheFrom) CacheFrom {
+		if v != nil {
+			return *v
+		}
+		var ret CacheFrom
+		return ret
+	}).(CacheFromOutput)
+}
+
+// Specifies cached images
+func (o CacheFromPtrOutput) Images() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *CacheFrom) []string {
+		if v == nil {
+			return nil
+		}
+		return v.Images
+	}).(pulumi.StringArrayOutput)
 }
 
 // The Docker build context
@@ -9595,8 +9680,8 @@ type DockerBuild struct {
 	Args map[string]string `pulumi:"args"`
 	// The version of the Docker builder.
 	BuilderVersion *BuilderVersion `pulumi:"builderVersion"`
-	// A cached image or list of build stages to use as build cache
-	CacheFrom interface{} `pulumi:"cacheFrom"`
+	// A list of images to use as build cache
+	CacheFrom *CacheFrom `pulumi:"cacheFrom"`
 	// The path to the build context to use.
 	Context *string `pulumi:"context"`
 	// The path to the Dockerfile to use.
@@ -9647,8 +9732,8 @@ type DockerBuildArgs struct {
 	Args pulumi.StringMapInput `pulumi:"args"`
 	// The version of the Docker builder.
 	BuilderVersion BuilderVersionPtrInput `pulumi:"builderVersion"`
-	// A cached image or list of build stages to use as build cache
-	CacheFrom pulumi.Input `pulumi:"cacheFrom"`
+	// A list of images to use as build cache
+	CacheFrom CacheFromPtrInput `pulumi:"cacheFrom"`
 	// The path to the build context to use.
 	Context pulumi.StringPtrInput `pulumi:"context"`
 	// The path to the Dockerfile to use.
@@ -9715,9 +9800,9 @@ func (o DockerBuildOutput) BuilderVersion() BuilderVersionPtrOutput {
 	return o.ApplyT(func(v DockerBuild) *BuilderVersion { return v.BuilderVersion }).(BuilderVersionPtrOutput)
 }
 
-// A cached image or list of build stages to use as build cache
-func (o DockerBuildOutput) CacheFrom() pulumi.AnyOutput {
-	return o.ApplyT(func(v DockerBuild) interface{} { return v.CacheFrom }).(pulumi.AnyOutput)
+// A list of images to use as build cache
+func (o DockerBuildOutput) CacheFrom() CacheFromPtrOutput {
+	return o.ApplyT(func(v DockerBuild) *CacheFrom { return v.CacheFrom }).(CacheFromPtrOutput)
 }
 
 // The path to the build context to use.
@@ -10155,6 +10240,7 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*VolumeLabelInput)(nil)).Elem(), VolumeLabelArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*VolumeLabelArrayInput)(nil)).Elem(), VolumeLabelArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*CacheFromInput)(nil)).Elem(), CacheFromArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*CacheFromPtrInput)(nil)).Elem(), CacheFromArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*DockerBuildInput)(nil)).Elem(), DockerBuildArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*GetNetworkIpamConfigInput)(nil)).Elem(), GetNetworkIpamConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*GetNetworkIpamConfigArrayInput)(nil)).Elem(), GetNetworkIpamConfigArray{})
@@ -10279,6 +10365,7 @@ func init() {
 	pulumi.RegisterOutputType(VolumeLabelOutput{})
 	pulumi.RegisterOutputType(VolumeLabelArrayOutput{})
 	pulumi.RegisterOutputType(CacheFromOutput{})
+	pulumi.RegisterOutputType(CacheFromPtrOutput{})
 	pulumi.RegisterOutputType(DockerBuildOutput{})
 	pulumi.RegisterOutputType(GetNetworkIpamConfigOutput{})
 	pulumi.RegisterOutputType(GetNetworkIpamConfigArrayOutput{})

--- a/sdk/java/src/main/java/com/pulumi/docker/inputs/CacheFromArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/inputs/CacheFromArgs.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 
 
 /**
- * Specifies information about where to obtain a cache
+ * Contains a list of images to reference when building using a cache
  * 
  */
 public final class CacheFromArgs extends com.pulumi.resources.ResourceArgs {
@@ -21,24 +21,24 @@ public final class CacheFromArgs extends com.pulumi.resources.ResourceArgs {
     public static final CacheFromArgs Empty = new CacheFromArgs();
 
     /**
-     * A list of cached build stages
+     * Specifies cached images
      * 
      */
-    @Import(name="stages")
-    private @Nullable Output<List<String>> stages;
+    @Import(name="images")
+    private @Nullable Output<List<String>> images;
 
     /**
-     * @return A list of cached build stages
+     * @return Specifies cached images
      * 
      */
-    public Optional<Output<List<String>>> stages() {
-        return Optional.ofNullable(this.stages);
+    public Optional<Output<List<String>>> images() {
+        return Optional.ofNullable(this.images);
     }
 
     private CacheFromArgs() {}
 
     private CacheFromArgs(CacheFromArgs $) {
-        this.stages = $.stages;
+        this.images = $.images;
     }
 
     public static Builder builder() {
@@ -60,34 +60,34 @@ public final class CacheFromArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param stages A list of cached build stages
+         * @param images Specifies cached images
          * 
          * @return builder
          * 
          */
-        public Builder stages(@Nullable Output<List<String>> stages) {
-            $.stages = stages;
+        public Builder images(@Nullable Output<List<String>> images) {
+            $.images = images;
             return this;
         }
 
         /**
-         * @param stages A list of cached build stages
+         * @param images Specifies cached images
          * 
          * @return builder
          * 
          */
-        public Builder stages(List<String> stages) {
-            return stages(Output.of(stages));
+        public Builder images(List<String> images) {
+            return images(Output.of(images));
         }
 
         /**
-         * @param stages A list of cached build stages
+         * @param images Specifies cached images
          * 
          * @return builder
          * 
          */
-        public Builder stages(String... stages) {
-            return stages(List.of(stages));
+        public Builder images(String... images) {
+            return images(List.of(images));
         }
 
         public CacheFromArgs build() {

--- a/sdk/java/src/main/java/com/pulumi/docker/inputs/DockerBuildArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/inputs/DockerBuildArgs.java
@@ -3,13 +3,11 @@
 
 package com.pulumi.docker.inputs;
 
-import com.pulumi.core.Either;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.core.internal.Codegen;
 import com.pulumi.docker.enums.BuilderVersion;
 import com.pulumi.docker.inputs.CacheFromArgs;
-import java.lang.Boolean;
 import java.lang.String;
 import java.util.List;
 import java.util.Map;
@@ -57,17 +55,17 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * A cached image or list of build stages to use as build cache
+     * A list of images to use as build cache
      * 
      */
     @Import(name="cacheFrom")
-    private @Nullable Output<Either<Boolean,CacheFromArgs>> cacheFrom;
+    private @Nullable Output<CacheFromArgs> cacheFrom;
 
     /**
-     * @return A cached image or list of build stages to use as build cache
+     * @return A list of images to use as build cache
      * 
      */
-    public Optional<Output<Either<Boolean,CacheFromArgs>>> cacheFrom() {
+    public Optional<Output<CacheFromArgs>> cacheFrom() {
         return Optional.ofNullable(this.cacheFrom);
     }
 
@@ -220,44 +218,24 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param cacheFrom A cached image or list of build stages to use as build cache
+         * @param cacheFrom A list of images to use as build cache
          * 
          * @return builder
          * 
          */
-        public Builder cacheFrom(@Nullable Output<Either<Boolean,CacheFromArgs>> cacheFrom) {
+        public Builder cacheFrom(@Nullable Output<CacheFromArgs> cacheFrom) {
             $.cacheFrom = cacheFrom;
             return this;
         }
 
         /**
-         * @param cacheFrom A cached image or list of build stages to use as build cache
-         * 
-         * @return builder
-         * 
-         */
-        public Builder cacheFrom(Either<Boolean,CacheFromArgs> cacheFrom) {
-            return cacheFrom(Output.of(cacheFrom));
-        }
-
-        /**
-         * @param cacheFrom A cached image or list of build stages to use as build cache
-         * 
-         * @return builder
-         * 
-         */
-        public Builder cacheFrom(Boolean cacheFrom) {
-            return cacheFrom(Either.ofLeft(cacheFrom));
-        }
-
-        /**
-         * @param cacheFrom A cached image or list of build stages to use as build cache
+         * @param cacheFrom A list of images to use as build cache
          * 
          * @return builder
          * 
          */
         public Builder cacheFrom(CacheFromArgs cacheFrom) {
-            return cacheFrom(Either.ofRight(cacheFrom));
+            return cacheFrom(Output.of(cacheFrom));
         }
 
         /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -9,13 +9,13 @@ import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
 /**
- * Specifies information about where to obtain a cache
+ * Contains a list of images to reference when building using a cache
  */
 export interface CacheFrom {
     /**
-     * A list of cached build stages
+     * Specifies cached images
      */
-    stages?: pulumi.Input<pulumi.Input<string>[]>;
+    images?: pulumi.Input<pulumi.Input<string>[]>;
 }
 
 export interface ContainerCapabilities {
@@ -288,9 +288,9 @@ export interface DockerBuild {
      */
     builderVersion?: pulumi.Input<enums.BuilderVersion>;
     /**
-     * A cached image or list of build stages to use as build cache
+     * A list of images to use as build cache
      */
-    cacheFrom?: pulumi.Input<boolean | inputs.CacheFrom>;
+    cacheFrom?: pulumi.Input<inputs.CacheFrom>;
     /**
      * The path to the build context to use.
      */

--- a/sdk/python/pulumi_docker/_inputs.py
+++ b/sdk/python/pulumi_docker/_inputs.py
@@ -4030,25 +4030,25 @@ class VolumeLabelArgs:
 @pulumi.input_type
 class CacheFromArgs:
     def __init__(__self__, *,
-                 stages: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
+                 images: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
         """
-        Specifies information about where to obtain a cache
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] stages: A list of cached build stages
+        Contains a list of images to reference when building using a cache
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] images: Specifies cached images
         """
-        if stages is not None:
-            pulumi.set(__self__, "stages", stages)
+        if images is not None:
+            pulumi.set(__self__, "images", images)
 
     @property
     @pulumi.getter
-    def stages(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+    def images(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
         """
-        A list of cached build stages
+        Specifies cached images
         """
-        return pulumi.get(self, "stages")
+        return pulumi.get(self, "images")
 
-    @stages.setter
-    def stages(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
-        pulumi.set(self, "stages", value)
+    @images.setter
+    def images(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "images", value)
 
 
 @pulumi.input_type
@@ -4056,7 +4056,7 @@ class DockerBuildArgs:
     def __init__(__self__, *,
                  args: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  builder_version: Optional[pulumi.Input['BuilderVersion']] = None,
-                 cache_from: Optional[pulumi.Input[Union[bool, 'CacheFromArgs']]] = None,
+                 cache_from: Optional[pulumi.Input['CacheFromArgs']] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
                  env: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
@@ -4066,7 +4066,7 @@ class DockerBuildArgs:
         The Docker build context
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] args: An optional map of named build-time argument variables to set during the Docker build. This flag allows you to pass built-time variablesthat can be accessed like environment variables inside the RUN instruction.
         :param pulumi.Input['BuilderVersion'] builder_version: The version of the Docker builder. 
-        :param pulumi.Input[Union[bool, 'CacheFromArgs']] cache_from: A cached image or list of build stages to use as build cache
+        :param pulumi.Input['CacheFromArgs'] cache_from: A list of images to use as build cache
         :param pulumi.Input[str] context: The path to the build context to use.
         :param pulumi.Input[str] dockerfile: The path to the Dockerfile to use.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] env: Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
@@ -4122,14 +4122,14 @@ class DockerBuildArgs:
 
     @property
     @pulumi.getter(name="cacheFrom")
-    def cache_from(self) -> Optional[pulumi.Input[Union[bool, 'CacheFromArgs']]]:
+    def cache_from(self) -> Optional[pulumi.Input['CacheFromArgs']]:
         """
-        A cached image or list of build stages to use as build cache
+        A list of images to use as build cache
         """
         return pulumi.get(self, "cache_from")
 
     @cache_from.setter
-    def cache_from(self, value: Optional[pulumi.Input[Union[bool, 'CacheFromArgs']]]):
+    def cache_from(self, value: Optional[pulumi.Input['CacheFromArgs']]):
         pulumi.set(self, "cache_from", value)
 
     @property


### PR DESCRIPTION
Fixes #427
Fixes #426

The v3.x.x implementation of cacheFrom did not properly reflect its use as a Docker command flag.
This pull request enables the `cacheFrom` type on the `build` type of `docker.Image` resource.
It accepts a list of images that can be pulled from an authenticated registry to serve as a build cache.
These images must have caching metadata information associated; otherwise Docker won't find them and build without cache.

This PR in its current state removes the OneOf implementation for `cacheFrom`, requiring the developer to explicitly add any image names to the `images` list. I am happy to revert this removal if we consider it necessary.

There is also a slight tweak to log handling output to avoid printing bytes 😅 

- re-schematize cacheFrom to properly reflect its use in the context of Docker
- Remove bool logic and update test to reflect new field name
- Enable cache-from
- Generate SDKS
