### PR TITLE
Deprecate extraOptions and env

### DIFF
--- a/examples/dockerfile-go/main.go
+++ b/examples/dockerfile-go/main.go
@@ -11,8 +11,8 @@ func main() {
 			ImageName: pulumi.String("pulumi-user/example:v1.0.0"),
 			Build: docker.DockerBuildArgs{
 				Target: pulumi.String("dependencies"),
-				Env: pulumi.StringMap{
-					"TEST_ENV": pulumi.String("42"),
+				Args: pulumi.StringMap{
+					"TEST_ARG": pulumi.String("42"),
 				},
 			},
 			SkipPush: pulumi.Bool(true),

--- a/examples/dockerfile-py/__main__.py
+++ b/examples/dockerfile-py/__main__.py
@@ -6,7 +6,7 @@ image = Image(
     image_name="pulumi-user/example:v1.0.0",
     build=DockerBuildArgs(
         target="dependencies",
-        env={'TEST_ENV': '42'},
+        args={'TEST_ARG': '42'},
     ),
     skip_push=True,
 )

--- a/examples/dockerfile-with-targets/index.ts
+++ b/examples/dockerfile-with-targets/index.ts
@@ -4,7 +4,7 @@ const myDependenciesImage = new docker.Image("my-image", {
     imageName: "pulumi-user/example:v1.0.0",
     build: {
         target: "dependencies",
-        env: { "TEST_ENV": "42" },
+        args: { "TEST_ARG": "42" },
     },
     skipPush: true,
 });

--- a/examples/dotnet/Program.cs
+++ b/examples/dotnet/Program.cs
@@ -15,9 +15,9 @@ class Program
                 ImageName = "pulumi-user/example:v1.0.0",
                 Build = new DockerBuildArgs
                 {
-                    Env = new Dictionary<string, string>
+                    Args = new Dictionary<string, string>
                     { 
-                        {"TEST_ENV", "42"}, 
+                        {"TEST_ARG", "42"},
                     },
                     Target = "dependencies",
                 },

--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -3074,13 +3074,6 @@
                     "description": "The path to the Dockerfile to use.",
                     "default": "Dockerfile"
                 },
-                "env": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "description": "Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build."
-                },
                 "extraOptions": {
                     "type": "array",
                     "items": {

--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -3074,13 +3074,6 @@
                     "description": "The path to the Dockerfile to use.",
                     "default": "Dockerfile"
                 },
-                "extraOptions": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "A bag of extra options to pass on to the docker SDK."
-                },
                 "target": {
                     "type": "string",
                     "description": "The target of the Dockerfile to build"

--- a/provider/image.go
+++ b/provider/image.go
@@ -45,7 +45,6 @@ type Build struct {
 	Context        string
 	Dockerfile     string
 	CachedImages   []string
-	Env            map[string]string
 	Args           map[string]*string
 	ExtraOptions   []string
 	Target         string
@@ -301,9 +300,6 @@ func marshalBuildAndApplyDefaults(b resource.PropertyValue) (Build, error) {
 	}
 	build.BuilderVersion = version
 
-	// Envs
-	build.Env = marshalEnvs(buildObject["env"])
-
 	// Args
 	build.Args = marshalArgs(buildObject["args"])
 
@@ -373,20 +369,6 @@ func marshalArgs(a resource.PropertyValue) map[string]*string {
 		return nil
 	}
 	return args
-}
-
-func marshalEnvs(e resource.PropertyValue) map[string]string {
-	envs := make(map[string]string)
-	if !e.IsNull() {
-		for k, v := range e.ObjectValue() {
-			key := fmt.Sprintf("%v", k)
-			envs[key] = v.StringValue()
-		}
-	}
-	if len(envs) == 0 {
-		return nil
-	}
-	return envs
 }
 
 func marshalBuilder(builder resource.PropertyValue) (types.BuilderVersion, error) {

--- a/provider/image.go
+++ b/provider/image.go
@@ -46,7 +46,6 @@ type Build struct {
 	Dockerfile     string
 	CachedImages   []string
 	Args           map[string]*string
-	ExtraOptions   []string
 	Target         string
 	BuilderVersion types.BuilderVersion
 }
@@ -302,14 +301,6 @@ func marshalBuildAndApplyDefaults(b resource.PropertyValue) (Build, error) {
 
 	// Args
 	build.Args = marshalArgs(buildObject["args"])
-
-	// ExtraOptions
-	if !buildObject["extraOptions"].IsNull() {
-		opts := buildObject["extraOptions"].ArrayValue()
-		for _, v := range opts {
-			build.ExtraOptions = append(build.ExtraOptions, v.StringValue())
-		}
-	}
 
 	// Target
 	if !buildObject["target"].IsNull() {

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -125,42 +125,6 @@ func TestMarshalBuildAndApplyDefaults(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Sets Extra Options", func(t *testing.T) {
-		expected := Build{
-			Context:        ".",
-			Dockerfile:     "Dockerfile",
-			ExtraOptions:   []string{"cat", "dog", "pot-bellied pig"},
-			BuilderVersion: "2",
-		}
-
-		input := resource.NewObjectProperty(resource.PropertyMap{
-			"extraOptions": resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("cat"),
-				resource.NewStringProperty("dog"),
-				resource.NewStringProperty("pot-bellied pig"),
-			}),
-		})
-
-		actual, err := marshalBuildAndApplyDefaults(input)
-		assert.Equal(t, expected, actual)
-		assert.NoError(t, err)
-	})
-
-	t.Run("Does Not Set Extra Options on Empty Input", func(t *testing.T) {
-		expected := Build{
-			Context:        ".",
-			Dockerfile:     "Dockerfile",
-			BuilderVersion: "2",
-		}
-
-		input := resource.NewObjectProperty(resource.PropertyMap{
-			"extraOptions": resource.NewArrayProperty([]resource.PropertyValue{}),
-		})
-
-		actual, err := marshalBuildAndApplyDefaults(input)
-		assert.Equal(t, expected, actual)
-		assert.NoError(t, err)
-	})
 	t.Run("Sets Target", func(t *testing.T) {
 		expected := Build{
 			Context:        ".",

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -125,28 +125,6 @@ func TestMarshalBuildAndApplyDefaults(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Setting Env", func(t *testing.T) {
-
-		expected := Build{
-			Context:    ".",
-			Dockerfile: "Dockerfile",
-			Env: map[string]string{
-				"Strawberry": "fruit",
-			},
-			BuilderVersion: "2",
-		}
-
-		input := resource.NewObjectProperty(resource.PropertyMap{
-			"env": resource.NewObjectProperty(resource.PropertyMap{
-				"Strawberry": resource.NewStringProperty("fruit"),
-			}),
-		})
-
-		actual, err := marshalBuildAndApplyDefaults(input)
-		assert.Equal(t, expected, actual)
-		assert.NoError(t, err)
-	})
-
 	t.Run("Sets Extra Options", func(t *testing.T) {
 		expected := Build{
 			Context:        ".",
@@ -252,29 +230,6 @@ func TestMarshalArgs(t *testing.T) {
 		expected := map[string]*string(nil)
 		input := resource.NewObjectProperty(resource.PropertyMap{})
 		actual := marshalArgs(input)
-		assert.Equal(t, expected, actual)
-	})
-}
-
-func TestMarshalEnvs(t *testing.T) {
-	t.Run("Set any environment variables", func(t *testing.T) {
-		expected := map[string]string{
-			"Strawberry": "fruit",
-			"Carrot":     "veggie",
-			"Docker":     "a bit of a mess tbh",
-		}
-		input := resource.NewObjectProperty(resource.PropertyMap{
-			"Strawberry": resource.NewStringProperty("fruit"),
-			"Carrot":     resource.NewStringProperty("veggie"),
-			"Docker":     resource.NewStringProperty("a bit of a mess tbh"),
-		})
-		actual := marshalEnvs(input)
-		assert.Equal(t, expected, actual)
-	})
-	t.Run("Returns nil when no environment variables set", func(t *testing.T) {
-		expected := map[string]string(nil)
-		input := resource.NewObjectProperty(resource.PropertyMap{})
-		actual := marshalEnvs(input)
 		assert.Equal(t, expected, actual)
 	})
 }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -168,15 +168,6 @@ func Provider() tfbridge.ProviderInfo {
 								},
 							},
 						},
-						"extraOptions": {
-							Description: "A bag of extra options to pass on to the docker SDK.",
-							TypeSpec: schema.TypeSpec{
-								Type: "array",
-								Items: &schema.TypeSpec{
-									Type: "string",
-								},
-							},
-						},
 						"target": {
 							Description: "The target of the Dockerfile to build",
 							TypeSpec:    schema.TypeSpec{Type: "string"},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -157,16 +157,6 @@ func Provider() tfbridge.ProviderInfo {
 								Ref: "#/types/docker:index/cacheFrom:CacheFrom",
 							},
 						},
-						"env": {
-							Description: "Environment variables to set on the invocation of docker build, " +
-								"for example to support DOCKER_BUILDKIT=1 docker build.",
-							TypeSpec: schema.TypeSpec{
-								Type: "object",
-								AdditionalProperties: &schema.TypeSpec{
-									Type: "string",
-								},
-							},
-						},
 						"args": {
 							Description: "An optional map of named build-time argument variables to set " +
 								"during the Docker build. This flag allows you to pass built-time variables" +

--- a/sdk/dotnet/Inputs/DockerBuildArgs.cs
+++ b/sdk/dotnet/Inputs/DockerBuildArgs.cs
@@ -51,18 +51,6 @@ namespace Pulumi.Docker.Inputs
         [Input("dockerfile")]
         public Input<string>? Dockerfile { get; set; }
 
-        [Input("extraOptions")]
-        private InputList<string>? _extraOptions;
-
-        /// <summary>
-        /// A bag of extra options to pass on to the docker SDK.
-        /// </summary>
-        public InputList<string> ExtraOptions
-        {
-            get => _extraOptions ?? (_extraOptions = new InputList<string>());
-            set => _extraOptions = value;
-        }
-
         /// <summary>
         /// The target of the Dockerfile to build
         /// </summary>

--- a/sdk/dotnet/Inputs/DockerBuildArgs.cs
+++ b/sdk/dotnet/Inputs/DockerBuildArgs.cs
@@ -51,18 +51,6 @@ namespace Pulumi.Docker.Inputs
         [Input("dockerfile")]
         public Input<string>? Dockerfile { get; set; }
 
-        [Input("env")]
-        private InputMap<string>? _env;
-
-        /// <summary>
-        /// Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
-        /// </summary>
-        public InputMap<string> Env
-        {
-            get => _env ?? (_env = new InputMap<string>());
-            set => _env = value;
-        }
-
         [Input("extraOptions")]
         private InputList<string>? _extraOptions;
 

--- a/sdk/go/docker/pulumiTypes.go
+++ b/sdk/go/docker/pulumiTypes.go
@@ -9686,8 +9686,6 @@ type DockerBuild struct {
 	Context *string `pulumi:"context"`
 	// The path to the Dockerfile to use.
 	Dockerfile *string `pulumi:"dockerfile"`
-	// Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
-	Env map[string]string `pulumi:"env"`
 	// A bag of extra options to pass on to the docker SDK.
 	ExtraOptions []string `pulumi:"extraOptions"`
 	// The target of the Dockerfile to build
@@ -9738,8 +9736,6 @@ type DockerBuildArgs struct {
 	Context pulumi.StringPtrInput `pulumi:"context"`
 	// The path to the Dockerfile to use.
 	Dockerfile pulumi.StringPtrInput `pulumi:"dockerfile"`
-	// Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
-	Env pulumi.StringMapInput `pulumi:"env"`
 	// A bag of extra options to pass on to the docker SDK.
 	ExtraOptions pulumi.StringArrayInput `pulumi:"extraOptions"`
 	// The target of the Dockerfile to build
@@ -9813,11 +9809,6 @@ func (o DockerBuildOutput) Context() pulumi.StringPtrOutput {
 // The path to the Dockerfile to use.
 func (o DockerBuildOutput) Dockerfile() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v DockerBuild) *string { return v.Dockerfile }).(pulumi.StringPtrOutput)
-}
-
-// Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
-func (o DockerBuildOutput) Env() pulumi.StringMapOutput {
-	return o.ApplyT(func(v DockerBuild) map[string]string { return v.Env }).(pulumi.StringMapOutput)
 }
 
 // A bag of extra options to pass on to the docker SDK.

--- a/sdk/go/docker/pulumiTypes.go
+++ b/sdk/go/docker/pulumiTypes.go
@@ -9686,8 +9686,6 @@ type DockerBuild struct {
 	Context *string `pulumi:"context"`
 	// The path to the Dockerfile to use.
 	Dockerfile *string `pulumi:"dockerfile"`
-	// A bag of extra options to pass on to the docker SDK.
-	ExtraOptions []string `pulumi:"extraOptions"`
 	// The target of the Dockerfile to build
 	Target *string `pulumi:"target"`
 }
@@ -9736,8 +9734,6 @@ type DockerBuildArgs struct {
 	Context pulumi.StringPtrInput `pulumi:"context"`
 	// The path to the Dockerfile to use.
 	Dockerfile pulumi.StringPtrInput `pulumi:"dockerfile"`
-	// A bag of extra options to pass on to the docker SDK.
-	ExtraOptions pulumi.StringArrayInput `pulumi:"extraOptions"`
 	// The target of the Dockerfile to build
 	Target pulumi.StringPtrInput `pulumi:"target"`
 }
@@ -9809,11 +9805,6 @@ func (o DockerBuildOutput) Context() pulumi.StringPtrOutput {
 // The path to the Dockerfile to use.
 func (o DockerBuildOutput) Dockerfile() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v DockerBuild) *string { return v.Dockerfile }).(pulumi.StringPtrOutput)
-}
-
-// A bag of extra options to pass on to the docker SDK.
-func (o DockerBuildOutput) ExtraOptions() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v DockerBuild) []string { return v.ExtraOptions }).(pulumi.StringArrayOutput)
 }
 
 // The target of the Dockerfile to build

--- a/sdk/java/src/main/java/com/pulumi/docker/inputs/DockerBuildArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/inputs/DockerBuildArgs.java
@@ -100,21 +100,6 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
-     * 
-     */
-    @Import(name="env")
-    private @Nullable Output<Map<String,String>> env;
-
-    /**
-     * @return Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
-     * 
-     */
-    public Optional<Output<Map<String,String>>> env() {
-        return Optional.ofNullable(this.env);
-    }
-
-    /**
      * A bag of extra options to pass on to the docker SDK.
      * 
      */
@@ -152,7 +137,6 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
         this.cacheFrom = $.cacheFrom;
         this.context = $.context;
         this.dockerfile = $.dockerfile;
-        this.env = $.env;
         this.extraOptions = $.extraOptions;
         this.target = $.target;
     }
@@ -278,27 +262,6 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder dockerfile(String dockerfile) {
             return dockerfile(Output.of(dockerfile));
-        }
-
-        /**
-         * @param env Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder env(@Nullable Output<Map<String,String>> env) {
-            $.env = env;
-            return this;
-        }
-
-        /**
-         * @param env Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder env(Map<String,String> env) {
-            return env(Output.of(env));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/docker/inputs/DockerBuildArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/inputs/DockerBuildArgs.java
@@ -9,7 +9,6 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.docker.enums.BuilderVersion;
 import com.pulumi.docker.inputs.CacheFromArgs;
 import java.lang.String;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -100,21 +99,6 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * A bag of extra options to pass on to the docker SDK.
-     * 
-     */
-    @Import(name="extraOptions")
-    private @Nullable Output<List<String>> extraOptions;
-
-    /**
-     * @return A bag of extra options to pass on to the docker SDK.
-     * 
-     */
-    public Optional<Output<List<String>>> extraOptions() {
-        return Optional.ofNullable(this.extraOptions);
-    }
-
-    /**
      * The target of the Dockerfile to build
      * 
      */
@@ -137,7 +121,6 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
         this.cacheFrom = $.cacheFrom;
         this.context = $.context;
         this.dockerfile = $.dockerfile;
-        this.extraOptions = $.extraOptions;
         this.target = $.target;
     }
 
@@ -262,37 +245,6 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder dockerfile(String dockerfile) {
             return dockerfile(Output.of(dockerfile));
-        }
-
-        /**
-         * @param extraOptions A bag of extra options to pass on to the docker SDK.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder extraOptions(@Nullable Output<List<String>> extraOptions) {
-            $.extraOptions = extraOptions;
-            return this;
-        }
-
-        /**
-         * @param extraOptions A bag of extra options to pass on to the docker SDK.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder extraOptions(List<String> extraOptions) {
-            return extraOptions(Output.of(extraOptions));
-        }
-
-        /**
-         * @param extraOptions A bag of extra options to pass on to the docker SDK.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder extraOptions(String... extraOptions) {
-            return extraOptions(List.of(extraOptions));
         }
 
         /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -300,10 +300,6 @@ export interface DockerBuild {
      */
     dockerfile?: pulumi.Input<string>;
     /**
-     * Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
-     */
-    env?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-    /**
      * A bag of extra options to pass on to the docker SDK.
      */
     extraOptions?: pulumi.Input<pulumi.Input<string>[]>;

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -300,10 +300,6 @@ export interface DockerBuild {
      */
     dockerfile?: pulumi.Input<string>;
     /**
-     * A bag of extra options to pass on to the docker SDK.
-     */
-    extraOptions?: pulumi.Input<pulumi.Input<string>[]>;
-    /**
      * The target of the Dockerfile to build
      */
     target?: pulumi.Input<string>;

--- a/sdk/python/pulumi_docker/_inputs.py
+++ b/sdk/python/pulumi_docker/_inputs.py
@@ -4059,7 +4059,6 @@ class DockerBuildArgs:
                  cache_from: Optional[pulumi.Input['CacheFromArgs']] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
-                 env: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  extra_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  target: Optional[pulumi.Input[str]] = None):
         """
@@ -4069,7 +4068,6 @@ class DockerBuildArgs:
         :param pulumi.Input['CacheFromArgs'] cache_from: A list of images to use as build cache
         :param pulumi.Input[str] context: The path to the build context to use.
         :param pulumi.Input[str] dockerfile: The path to the Dockerfile to use.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] env: Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] extra_options: A bag of extra options to pass on to the docker SDK.
         :param pulumi.Input[str] target: The target of the Dockerfile to build
         """
@@ -4089,8 +4087,6 @@ class DockerBuildArgs:
             dockerfile = 'Dockerfile'
         if dockerfile is not None:
             pulumi.set(__self__, "dockerfile", dockerfile)
-        if env is not None:
-            pulumi.set(__self__, "env", env)
         if extra_options is not None:
             pulumi.set(__self__, "extra_options", extra_options)
         if target is not None:
@@ -4155,18 +4151,6 @@ class DockerBuildArgs:
     @dockerfile.setter
     def dockerfile(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "dockerfile", value)
-
-    @property
-    @pulumi.getter
-    def env(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
-        """
-        Environment variables to set on the invocation of docker build, for example to support DOCKER_BUILDKIT=1 docker build.
-        """
-        return pulumi.get(self, "env")
-
-    @env.setter
-    def env(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
-        pulumi.set(self, "env", value)
 
     @property
     @pulumi.getter(name="extraOptions")

--- a/sdk/python/pulumi_docker/_inputs.py
+++ b/sdk/python/pulumi_docker/_inputs.py
@@ -4059,7 +4059,6 @@ class DockerBuildArgs:
                  cache_from: Optional[pulumi.Input['CacheFromArgs']] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
-                 extra_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  target: Optional[pulumi.Input[str]] = None):
         """
         The Docker build context
@@ -4068,7 +4067,6 @@ class DockerBuildArgs:
         :param pulumi.Input['CacheFromArgs'] cache_from: A list of images to use as build cache
         :param pulumi.Input[str] context: The path to the build context to use.
         :param pulumi.Input[str] dockerfile: The path to the Dockerfile to use.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] extra_options: A bag of extra options to pass on to the docker SDK.
         :param pulumi.Input[str] target: The target of the Dockerfile to build
         """
         if args is not None:
@@ -4087,8 +4085,6 @@ class DockerBuildArgs:
             dockerfile = 'Dockerfile'
         if dockerfile is not None:
             pulumi.set(__self__, "dockerfile", dockerfile)
-        if extra_options is not None:
-            pulumi.set(__self__, "extra_options", extra_options)
         if target is not None:
             pulumi.set(__self__, "target", target)
 
@@ -4151,18 +4147,6 @@ class DockerBuildArgs:
     @dockerfile.setter
     def dockerfile(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "dockerfile", value)
-
-    @property
-    @pulumi.getter(name="extraOptions")
-    def extra_options(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
-        """
-        A bag of extra options to pass on to the docker SDK.
-        """
-        return pulumi.get(self, "extra_options")
-
-    @extra_options.setter
-    def extra_options(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
-        pulumi.set(self, "extra_options", value)
 
     @property
     @pulumi.getter


### PR DESCRIPTION
This PR cleans up:

`env` - it was used to pass CLI environment variables like `BUILDKIT=1` and we now have `builderVersion` instead

`extraOptions` - we cannot support a grab bag of command line options when using the docker SDK.

- Remove `env` from schema
- Remove handling of deprecated `env` field from Image implementation
- Generate SDKs for removal of `env` type
- Remove `extraOptions` field
- Remove extraOptions implementation and tests
- Regenerate SDKs

Fixes #469
