### PR TITLE
Enable cross platform builds

### DIFF
--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -3074,6 +3074,10 @@
                     "description": "The path to the Dockerfile to use.",
                     "default": "Dockerfile"
                 },
+                "platform": {
+                    "type": "string",
+                    "description": " Set platform if server is multi-platform capable"
+                },
                 "target": {
                     "type": "string",
                     "description": "The target of the Dockerfile to build"

--- a/provider/image.go
+++ b/provider/image.go
@@ -47,6 +47,7 @@ type Build struct {
 	CachedImages   []string
 	Args           map[string]*string
 	Target         string
+	Platform       string
 	BuilderVersion types.BuilderVersion
 }
 
@@ -112,6 +113,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		CacheFrom:  img.Build.CachedImages,
 		BuildArgs:  build.Args,
 		Version:    build.BuilderVersion,
+		Platform:   build.Platform,
 
 		AuthConfigs: authConfigs,
 	}
@@ -305,6 +307,11 @@ func marshalBuildAndApplyDefaults(b resource.PropertyValue) (Build, error) {
 	// Target
 	if !buildObject["target"].IsNull() {
 		build.Target = buildObject["target"].StringValue()
+	}
+
+	// Platform
+	if !buildObject["platform"].IsNull() {
+		build.Platform = buildObject["platform"].StringValue()
 	}
 	return build, nil
 }

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -141,6 +141,22 @@ func TestMarshalBuildAndApplyDefaults(t *testing.T) {
 		assert.Equal(t, expected, actual)
 		assert.NoError(t, err)
 	})
+	t.Run("Sets Platform", func(t *testing.T) {
+		expected := Build{
+			Context:        ".",
+			Dockerfile:     "Dockerfile",
+			Platform:       "linux/leg32",
+			BuilderVersion: "2",
+		}
+
+		input := resource.NewObjectProperty(resource.PropertyMap{
+			"platform": resource.NewStringProperty("linux/leg32"),
+		})
+
+		actual, err := marshalBuildAndApplyDefaults(input)
+		assert.Equal(t, expected, actual)
+		assert.NoError(t, err)
+	})
 	t.Run("Sets Builder to classic V1 builder", func(t *testing.T) {
 		expected := Build{
 			Context:        ".",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -179,6 +179,10 @@ func Provider() tfbridge.ProviderInfo {
 							},
 							Default: "BuilderBuildKit",
 						},
+						"platform": {
+							Description: " Set platform if server is multi-platform capable",
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+						},
 					},
 				},
 			},

--- a/sdk/dotnet/Inputs/DockerBuildArgs.cs
+++ b/sdk/dotnet/Inputs/DockerBuildArgs.cs
@@ -52,6 +52,12 @@ namespace Pulumi.Docker.Inputs
         public Input<string>? Dockerfile { get; set; }
 
         /// <summary>
+        ///  Set platform if server is multi-platform capable
+        /// </summary>
+        [Input("platform")]
+        public Input<string>? Platform { get; set; }
+
+        /// <summary>
         /// The target of the Dockerfile to build
         /// </summary>
         [Input("target")]

--- a/sdk/go/docker/pulumiTypes.go
+++ b/sdk/go/docker/pulumiTypes.go
@@ -9686,6 +9686,8 @@ type DockerBuild struct {
 	Context *string `pulumi:"context"`
 	// The path to the Dockerfile to use.
 	Dockerfile *string `pulumi:"dockerfile"`
+	//  Set platform if server is multi-platform capable
+	Platform *string `pulumi:"platform"`
 	// The target of the Dockerfile to build
 	Target *string `pulumi:"target"`
 }
@@ -9734,6 +9736,8 @@ type DockerBuildArgs struct {
 	Context pulumi.StringPtrInput `pulumi:"context"`
 	// The path to the Dockerfile to use.
 	Dockerfile pulumi.StringPtrInput `pulumi:"dockerfile"`
+	//  Set platform if server is multi-platform capable
+	Platform pulumi.StringPtrInput `pulumi:"platform"`
 	// The target of the Dockerfile to build
 	Target pulumi.StringPtrInput `pulumi:"target"`
 }
@@ -9805,6 +9809,11 @@ func (o DockerBuildOutput) Context() pulumi.StringPtrOutput {
 // The path to the Dockerfile to use.
 func (o DockerBuildOutput) Dockerfile() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v DockerBuild) *string { return v.Dockerfile }).(pulumi.StringPtrOutput)
+}
+
+// Set platform if server is multi-platform capable
+func (o DockerBuildOutput) Platform() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v DockerBuild) *string { return v.Platform }).(pulumi.StringPtrOutput)
 }
 
 // The target of the Dockerfile to build

--- a/sdk/java/src/main/java/com/pulumi/docker/inputs/DockerBuildArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/inputs/DockerBuildArgs.java
@@ -99,6 +99,21 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     *  Set platform if server is multi-platform capable
+     * 
+     */
+    @Import(name="platform")
+    private @Nullable Output<String> platform;
+
+    /**
+     * @return  Set platform if server is multi-platform capable
+     * 
+     */
+    public Optional<Output<String>> platform() {
+        return Optional.ofNullable(this.platform);
+    }
+
+    /**
      * The target of the Dockerfile to build
      * 
      */
@@ -121,6 +136,7 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
         this.cacheFrom = $.cacheFrom;
         this.context = $.context;
         this.dockerfile = $.dockerfile;
+        this.platform = $.platform;
         this.target = $.target;
     }
 
@@ -245,6 +261,27 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder dockerfile(String dockerfile) {
             return dockerfile(Output.of(dockerfile));
+        }
+
+        /**
+         * @param platform  Set platform if server is multi-platform capable
+         * 
+         * @return builder
+         * 
+         */
+        public Builder platform(@Nullable Output<String> platform) {
+            $.platform = platform;
+            return this;
+        }
+
+        /**
+         * @param platform  Set platform if server is multi-platform capable
+         * 
+         * @return builder
+         * 
+         */
+        public Builder platform(String platform) {
+            return platform(Output.of(platform));
         }
 
         /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -300,6 +300,10 @@ export interface DockerBuild {
      */
     dockerfile?: pulumi.Input<string>;
     /**
+     *  Set platform if server is multi-platform capable
+     */
+    platform?: pulumi.Input<string>;
+    /**
      * The target of the Dockerfile to build
      */
     target?: pulumi.Input<string>;

--- a/sdk/python/pulumi_docker/_inputs.py
+++ b/sdk/python/pulumi_docker/_inputs.py
@@ -4059,6 +4059,7 @@ class DockerBuildArgs:
                  cache_from: Optional[pulumi.Input['CacheFromArgs']] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
+                 platform: Optional[pulumi.Input[str]] = None,
                  target: Optional[pulumi.Input[str]] = None):
         """
         The Docker build context
@@ -4067,6 +4068,7 @@ class DockerBuildArgs:
         :param pulumi.Input['CacheFromArgs'] cache_from: A list of images to use as build cache
         :param pulumi.Input[str] context: The path to the build context to use.
         :param pulumi.Input[str] dockerfile: The path to the Dockerfile to use.
+        :param pulumi.Input[str] platform:  Set platform if server is multi-platform capable
         :param pulumi.Input[str] target: The target of the Dockerfile to build
         """
         if args is not None:
@@ -4085,6 +4087,8 @@ class DockerBuildArgs:
             dockerfile = 'Dockerfile'
         if dockerfile is not None:
             pulumi.set(__self__, "dockerfile", dockerfile)
+        if platform is not None:
+            pulumi.set(__self__, "platform", platform)
         if target is not None:
             pulumi.set(__self__, "target", target)
 
@@ -4147,6 +4151,18 @@ class DockerBuildArgs:
     @dockerfile.setter
     def dockerfile(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "dockerfile", value)
+
+    @property
+    @pulumi.getter
+    def platform(self) -> Optional[pulumi.Input[str]]:
+        """
+         Set platform if server is multi-platform capable
+        """
+        return pulumi.get(self, "platform")
+
+    @platform.setter
+    def platform(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "platform", value)
 
     @property
     @pulumi.getter


### PR DESCRIPTION
This schematizes the `platform` build field, which provides
cross-platform build abilities akin to the docker CLI's `--platform`
flag.
When set, the provider will build an image for the platform specified.

Fixes #470
Fixes #296

- Add Platform build input
- Generate SDKs
