### PR TITLE
Bump goreleaser action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -333,7 +333,7 @@ jobs:
       run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
         >> $GITHUB_ENV
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v4
       with:
         args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           60m0s


### PR DESCRIPTION
[experimental] GoReleaser was not downloaded on a recent publish step on default branch.
We're two versions behind on the goreleaser action so this is an attempt to fix via version bump.

