### PR TITLE
Alias Docker image to avoid deletion on upgrade to v4

### DIFF
--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -4462,6 +4462,11 @@
             },
             "requiredInputs": [
                 "imageName"
+            ],
+            "aliases": [
+                {
+                    "type": "docker:image:Image"
+                }
             ]
         },
         "docker:index/network:Network": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -17,6 +17,7 @@ package provider
 import (
 	"fmt"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"path/filepath"
 	"unicode"
 
@@ -274,6 +275,11 @@ func Provider() tfbridge.ProviderInfo {
 					},
 				},
 				RequiredInputs: []string{"imageName"},
+				Aliases: []schema.AliasSpec{
+					{
+						Type: pulumi.StringRef("docker:image:Image"),
+					},
+				},
 			},
 		},
 

--- a/sdk/dotnet/Image.cs
+++ b/sdk/dotnet/Image.cs
@@ -86,6 +86,10 @@ namespace Pulumi.Docker
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                Aliases =
+                {
+                    new global::Pulumi.Alias { Type = "docker:image:Image"},
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/go/docker/image.go
+++ b/sdk/go/docker/image.go
@@ -70,6 +70,12 @@ func NewImage(ctx *pulumi.Context,
 	if isZero(args.SkipPush) {
 		args.SkipPush = pulumi.BoolPtr(false)
 	}
+	aliases := pulumi.Aliases([]pulumi.Alias{
+		{
+			Type: pulumi.String("docker:image:Image"),
+		},
+	})
+	opts = append(opts, aliases)
 	var resource Image
 	err := ctx.RegisterResource("docker:index/image:Image", name, args, &resource, opts...)
 	if err != nil {

--- a/sdk/java/src/main/java/com/pulumi/docker/Image.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/Image.java
@@ -3,6 +3,7 @@
 
 package com.pulumi.docker;
 
+import com.pulumi.core.Alias;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Export;
 import com.pulumi.core.annotations.ResourceType;
@@ -10,6 +11,7 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.docker.ImageArgs;
 import com.pulumi.docker.Utilities;
 import java.lang.String;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -130,6 +132,9 @@ public class Image extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .aliases(List.of(
+                Output.of(Alias.builder().type("docker:image:Image").build())
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/nodejs/image.ts
+++ b/sdk/nodejs/image.ts
@@ -96,6 +96,8 @@ export class Image extends pulumi.CustomResource {
             resourceInputs["registryServer"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const aliasOpts = { aliases: [{ type: "docker:image:Image" }] };
+        opts = pulumi.mergeOptions(opts, aliasOpts);
         super(Image.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/python/pulumi_docker/image.py
+++ b/sdk/python/pulumi_docker/image.py
@@ -189,6 +189,8 @@ class Image(pulumi.CustomResource):
             __props__.__dict__["skip_push"] = skip_push
             __props__.__dict__["base_image_name"] = None
             __props__.__dict__["registry_server"] = None
+        alias_opts = pulumi.ResourceOptions(aliases=[pulumi.Alias(type_="docker:image:Image")])
+        opts = pulumi.ResourceOptions.merge(opts, alias_opts)
         super(Image, __self__).__init__(
             'docker:index/image:Image',
             resource_name,


### PR DESCRIPTION
Adds the alias for the v3.x.x Docker image URN token to the new, schematized Image token.
Specifically, `docker:index/image:Image` is aliased to the previous `docker:index:Image`.
This should avoid delete/create of a resource during upgrade to v4.

- Add alias to Image
- generate schema and SDKs
