### PR TITLE
Add EOF condition to special error case handling

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -473,6 +473,11 @@ func processLogLine(msg string) (string, error) {
 		if jm.Error.Code == 401 {
 			return info, fmt.Errorf("authentication is required")
 		}
+		if jm.Error.Message == "EOF" {
+			return info, fmt.Errorf("%s\n: This error is most likely due to incorrect or mismatched registry "+
+				"credentials. Please double check you are using the correct credentials and registry name.",
+				jm.Error.Message)
+		}
 		return info, fmt.Errorf(jm.Error.Message)
 	}
 	if jm.From != "" {


### PR DESCRIPTION
This pull request adds an extra error handling step to the logging output.
In the case of a `docker push` to AWS, when credentials are incorrect or mismatched, we sometimes see Docker re-trying a push multiple times, only to ultimately fail with an uninformative `error: EOF`. This extra condition intercepts this error and adds more detail to the output.

Fixes #485
