### PR TITLE
Remove OneOf implementation for Build type

### DIFF
--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -4436,14 +4436,7 @@
             "type": "object",
             "inputProperties": {
                 "build": {
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/types/docker:index/dockerBuild:DockerBuild"
-                        }
-                    ],
+                    "$ref": "#/types/docker:index/dockerBuild:DockerBuild",
                     "description": "The Docker build context"
                 },
                 "imageName": {

--- a/provider/image.go
+++ b/provider/image.go
@@ -247,13 +247,6 @@ func marshalBuildAndApplyDefaults(b resource.PropertyValue) (Build, error) {
 		build.Context = "."
 		return build, nil
 	}
-	if b.IsString() {
-		// use the filepath as context
-		build.Context = b.StringValue()
-		build.Dockerfile = defaultDockerfile
-		return build, nil
-	}
-
 	// read in the build type fields
 	buildObject := b.ObjectValue()
 	// Dockerfile

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -62,17 +62,6 @@ func TestMarshalBuildAndApplyDefaults(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("String input Build", func(t *testing.T) {
-		expected := Build{
-			Context:    "/twilight/sparkle/bin",
-			Dockerfile: "Dockerfile",
-		}
-		input := resource.NewStringProperty("/twilight/sparkle/bin")
-		actual, err := marshalBuildAndApplyDefaults(input)
-		assert.Equal(t, expected, actual)
-		assert.NoError(t, err)
-	})
-
 	t.Run("Custom Dockerfile with default context", func(t *testing.T) {
 		expected := Build{
 			Context:        ".",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -261,14 +261,7 @@ func Provider() tfbridge.ProviderInfo {
 					"build": {
 						Description: "The Docker build context",
 						TypeSpec: schema.TypeSpec{
-							OneOf: []schema.TypeSpec{
-								{
-									Type: "string",
-								},
-								{
-									Ref: "#/types/docker:index/dockerBuild:DockerBuild",
-								},
-							},
+							Ref: "#/types/docker:index/dockerBuild:DockerBuild",
 						},
 					},
 					"skipPush": {

--- a/sdk/dotnet/Image.cs
+++ b/sdk/dotnet/Image.cs
@@ -116,7 +116,7 @@ namespace Pulumi.Docker
         /// The Docker build context
         /// </summary>
         [Input("build")]
-        public InputUnion<string, Inputs.DockerBuildArgs>? Build { get; set; }
+        public Input<Inputs.DockerBuildArgs>? Build { get; set; }
 
         /// <summary>
         /// The image name

--- a/sdk/go/docker/image.go
+++ b/sdk/go/docker/image.go
@@ -67,6 +67,9 @@ func NewImage(ctx *pulumi.Context,
 	if args.ImageName == nil {
 		return nil, errors.New("invalid value for required argument 'ImageName'")
 	}
+	if args.Build != nil {
+		args.Build = args.Build.ToDockerBuildPtrOutput().ApplyT(func(v *DockerBuild) *DockerBuild { return v.Defaults() }).(DockerBuildPtrOutput)
+	}
 	if isZero(args.SkipPush) {
 		args.SkipPush = pulumi.BoolPtr(false)
 	}
@@ -109,7 +112,7 @@ func (ImageState) ElementType() reflect.Type {
 
 type imageArgs struct {
 	// The Docker build context
-	Build interface{} `pulumi:"build"`
+	Build *DockerBuild `pulumi:"build"`
 	// The image name
 	ImageName string `pulumi:"imageName"`
 	// The registry to push the image to
@@ -121,7 +124,7 @@ type imageArgs struct {
 // The set of arguments for constructing a Image resource.
 type ImageArgs struct {
 	// The Docker build context
-	Build pulumi.Input
+	Build DockerBuildPtrInput
 	// The image name
 	ImageName pulumi.StringInput
 	// The registry to push the image to

--- a/sdk/go/docker/pulumiTypes.go
+++ b/sdk/go/docker/pulumiTypes.go
@@ -9771,6 +9771,47 @@ func (i DockerBuildArgs) ToDockerBuildOutputWithContext(ctx context.Context) Doc
 	return pulumi.ToOutputWithContext(ctx, i).(DockerBuildOutput)
 }
 
+func (i DockerBuildArgs) ToDockerBuildPtrOutput() DockerBuildPtrOutput {
+	return i.ToDockerBuildPtrOutputWithContext(context.Background())
+}
+
+func (i DockerBuildArgs) ToDockerBuildPtrOutputWithContext(ctx context.Context) DockerBuildPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DockerBuildOutput).ToDockerBuildPtrOutputWithContext(ctx)
+}
+
+// DockerBuildPtrInput is an input type that accepts DockerBuildArgs, DockerBuildPtr and DockerBuildPtrOutput values.
+// You can construct a concrete instance of `DockerBuildPtrInput` via:
+//
+//	        DockerBuildArgs{...}
+//
+//	or:
+//
+//	        nil
+type DockerBuildPtrInput interface {
+	pulumi.Input
+
+	ToDockerBuildPtrOutput() DockerBuildPtrOutput
+	ToDockerBuildPtrOutputWithContext(context.Context) DockerBuildPtrOutput
+}
+
+type dockerBuildPtrType DockerBuildArgs
+
+func DockerBuildPtr(v *DockerBuildArgs) DockerBuildPtrInput {
+	return (*dockerBuildPtrType)(v)
+}
+
+func (*dockerBuildPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**DockerBuild)(nil)).Elem()
+}
+
+func (i *dockerBuildPtrType) ToDockerBuildPtrOutput() DockerBuildPtrOutput {
+	return i.ToDockerBuildPtrOutputWithContext(context.Background())
+}
+
+func (i *dockerBuildPtrType) ToDockerBuildPtrOutputWithContext(ctx context.Context) DockerBuildPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DockerBuildPtrOutput)
+}
+
 // The Docker build context
 type DockerBuildOutput struct{ *pulumi.OutputState }
 
@@ -9784,6 +9825,16 @@ func (o DockerBuildOutput) ToDockerBuildOutput() DockerBuildOutput {
 
 func (o DockerBuildOutput) ToDockerBuildOutputWithContext(ctx context.Context) DockerBuildOutput {
 	return o
+}
+
+func (o DockerBuildOutput) ToDockerBuildPtrOutput() DockerBuildPtrOutput {
+	return o.ToDockerBuildPtrOutputWithContext(context.Background())
+}
+
+func (o DockerBuildOutput) ToDockerBuildPtrOutputWithContext(ctx context.Context) DockerBuildPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v DockerBuild) *DockerBuild {
+		return &v
+	}).(DockerBuildPtrOutput)
 }
 
 // An optional map of named build-time argument variables to set during the Docker build. This flag allows you to pass build-time variablesthat can be accessed like environment variables inside the RUN instruction.
@@ -9819,6 +9870,100 @@ func (o DockerBuildOutput) Platform() pulumi.StringPtrOutput {
 // The target of the Dockerfile to build
 func (o DockerBuildOutput) Target() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v DockerBuild) *string { return v.Target }).(pulumi.StringPtrOutput)
+}
+
+type DockerBuildPtrOutput struct{ *pulumi.OutputState }
+
+func (DockerBuildPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**DockerBuild)(nil)).Elem()
+}
+
+func (o DockerBuildPtrOutput) ToDockerBuildPtrOutput() DockerBuildPtrOutput {
+	return o
+}
+
+func (o DockerBuildPtrOutput) ToDockerBuildPtrOutputWithContext(ctx context.Context) DockerBuildPtrOutput {
+	return o
+}
+
+func (o DockerBuildPtrOutput) Elem() DockerBuildOutput {
+	return o.ApplyT(func(v *DockerBuild) DockerBuild {
+		if v != nil {
+			return *v
+		}
+		var ret DockerBuild
+		return ret
+	}).(DockerBuildOutput)
+}
+
+// An optional map of named build-time argument variables to set during the Docker build. This flag allows you to pass build-time variablesthat can be accessed like environment variables inside the RUN instruction.
+func (o DockerBuildPtrOutput) Args() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *DockerBuild) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.Args
+	}).(pulumi.StringMapOutput)
+}
+
+// The version of the Docker builder.
+func (o DockerBuildPtrOutput) BuilderVersion() BuilderVersionPtrOutput {
+	return o.ApplyT(func(v *DockerBuild) *BuilderVersion {
+		if v == nil {
+			return nil
+		}
+		return v.BuilderVersion
+	}).(BuilderVersionPtrOutput)
+}
+
+// A list of image names to use as build cache. Images provided must have a cache manifest. Must provide authentication to cache registry.
+func (o DockerBuildPtrOutput) CacheFrom() CacheFromPtrOutput {
+	return o.ApplyT(func(v *DockerBuild) *CacheFrom {
+		if v == nil {
+			return nil
+		}
+		return v.CacheFrom
+	}).(CacheFromPtrOutput)
+}
+
+// The path to the build context to use.
+func (o DockerBuildPtrOutput) Context() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *DockerBuild) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Context
+	}).(pulumi.StringPtrOutput)
+}
+
+// The path to the Dockerfile to use.
+func (o DockerBuildPtrOutput) Dockerfile() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *DockerBuild) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Dockerfile
+	}).(pulumi.StringPtrOutput)
+}
+
+// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
+func (o DockerBuildPtrOutput) Platform() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *DockerBuild) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Platform
+	}).(pulumi.StringPtrOutput)
+}
+
+// The target of the Dockerfile to build
+func (o DockerBuildPtrOutput) Target() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *DockerBuild) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Target
+	}).(pulumi.StringPtrOutput)
 }
 
 type GetNetworkIpamConfig struct {
@@ -10233,6 +10378,7 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*CacheFromInput)(nil)).Elem(), CacheFromArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*CacheFromPtrInput)(nil)).Elem(), CacheFromArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*DockerBuildInput)(nil)).Elem(), DockerBuildArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DockerBuildPtrInput)(nil)).Elem(), DockerBuildArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*GetNetworkIpamConfigInput)(nil)).Elem(), GetNetworkIpamConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*GetNetworkIpamConfigArrayInput)(nil)).Elem(), GetNetworkIpamConfigArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*RegistryInput)(nil)).Elem(), RegistryArgs{})
@@ -10358,6 +10504,7 @@ func init() {
 	pulumi.RegisterOutputType(CacheFromOutput{})
 	pulumi.RegisterOutputType(CacheFromPtrOutput{})
 	pulumi.RegisterOutputType(DockerBuildOutput{})
+	pulumi.RegisterOutputType(DockerBuildPtrOutput{})
 	pulumi.RegisterOutputType(GetNetworkIpamConfigOutput{})
 	pulumi.RegisterOutputType(GetNetworkIpamConfigArrayOutput{})
 	pulumi.RegisterOutputType(RegistryOutput{})

--- a/sdk/java/src/main/java/com/pulumi/docker/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/ImageArgs.java
@@ -3,7 +3,6 @@
 
 package com.pulumi.docker;
 
-import com.pulumi.core.Either;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.core.internal.Codegen;
@@ -25,13 +24,13 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="build")
-    private @Nullable Output<Either<String,DockerBuildArgs>> build;
+    private @Nullable Output<DockerBuildArgs> build;
 
     /**
      * @return The Docker build context
      * 
      */
-    public Optional<Output<Either<String,DockerBuildArgs>>> build() {
+    public Optional<Output<DockerBuildArgs>> build() {
         return Optional.ofNullable(this.build);
     }
 
@@ -113,7 +112,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder build(@Nullable Output<Either<String,DockerBuildArgs>> build) {
+        public Builder build(@Nullable Output<DockerBuildArgs> build) {
             $.build = build;
             return this;
         }
@@ -124,28 +123,8 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder build(Either<String,DockerBuildArgs> build) {
-            return build(Output.of(build));
-        }
-
-        /**
-         * @param build The Docker build context
-         * 
-         * @return builder
-         * 
-         */
-        public Builder build(String build) {
-            return build(Either.ofLeft(build));
-        }
-
-        /**
-         * @param build The Docker build context
-         * 
-         * @return builder
-         * 
-         */
         public Builder build(DockerBuildArgs build) {
-            return build(Either.ofRight(build));
+            return build(Output.of(build));
         }
 
         /**

--- a/sdk/nodejs/image.ts
+++ b/sdk/nodejs/image.ts
@@ -84,7 +84,7 @@ export class Image extends pulumi.CustomResource {
             if ((!args || args.imageName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'imageName'");
             }
-            resourceInputs["build"] = args ? args.build : undefined;
+            resourceInputs["build"] = args ? (args.build ? pulumi.output(args.build).apply(inputs.dockerBuildProvideDefaults) : undefined) : undefined;
             resourceInputs["imageName"] = args ? args.imageName : undefined;
             resourceInputs["registry"] = args ? args.registry : undefined;
             resourceInputs["skipPush"] = (args ? args.skipPush : undefined) ?? false;
@@ -109,7 +109,7 @@ export interface ImageArgs {
     /**
      * The Docker build context
      */
-    build?: pulumi.Input<string | inputs.DockerBuild>;
+    build?: pulumi.Input<inputs.DockerBuild>;
     /**
      * The image name
      */

--- a/sdk/python/pulumi_docker/image.py
+++ b/sdk/python/pulumi_docker/image.py
@@ -17,13 +17,13 @@ __all__ = ['ImageArgs', 'Image']
 class ImageArgs:
     def __init__(__self__, *,
                  image_name: pulumi.Input[str],
-                 build: Optional[pulumi.Input[Union[str, 'DockerBuildArgs']]] = None,
+                 build: Optional[pulumi.Input['DockerBuildArgs']] = None,
                  registry: Optional[pulumi.Input['RegistryArgs']] = None,
                  skip_push: Optional[pulumi.Input[bool]] = None):
         """
         The set of arguments for constructing a Image resource.
         :param pulumi.Input[str] image_name: The image name
-        :param pulumi.Input[Union[str, 'DockerBuildArgs']] build: The Docker build context
+        :param pulumi.Input['DockerBuildArgs'] build: The Docker build context
         :param pulumi.Input['RegistryArgs'] registry: The registry to push the image to
         :param pulumi.Input[bool] skip_push: A flag to skip a registry push.
         """
@@ -51,14 +51,14 @@ class ImageArgs:
 
     @property
     @pulumi.getter
-    def build(self) -> Optional[pulumi.Input[Union[str, 'DockerBuildArgs']]]:
+    def build(self) -> Optional[pulumi.Input['DockerBuildArgs']]:
         """
         The Docker build context
         """
         return pulumi.get(self, "build")
 
     @build.setter
-    def build(self, value: Optional[pulumi.Input[Union[str, 'DockerBuildArgs']]]):
+    def build(self, value: Optional[pulumi.Input['DockerBuildArgs']]):
         pulumi.set(self, "build", value)
 
     @property
@@ -91,7 +91,7 @@ class Image(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 build: Optional[pulumi.Input[Union[str, pulumi.InputType['DockerBuildArgs']]]] = None,
+                 build: Optional[pulumi.Input[pulumi.InputType['DockerBuildArgs']]] = None,
                  image_name: Optional[pulumi.Input[str]] = None,
                  registry: Optional[pulumi.Input[pulumi.InputType['RegistryArgs']]] = None,
                  skip_push: Optional[pulumi.Input[bool]] = None,
@@ -119,7 +119,7 @@ class Image(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Union[str, pulumi.InputType['DockerBuildArgs']]] build: The Docker build context
+        :param pulumi.Input[pulumi.InputType['DockerBuildArgs']] build: The Docker build context
         :param pulumi.Input[str] image_name: The image name
         :param pulumi.Input[pulumi.InputType['RegistryArgs']] registry: The registry to push the image to
         :param pulumi.Input[bool] skip_push: A flag to skip a registry push.
@@ -166,7 +166,7 @@ class Image(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 build: Optional[pulumi.Input[Union[str, pulumi.InputType['DockerBuildArgs']]]] = None,
+                 build: Optional[pulumi.Input[pulumi.InputType['DockerBuildArgs']]] = None,
                  image_name: Optional[pulumi.Input[str]] = None,
                  registry: Optional[pulumi.Input[pulumi.InputType['RegistryArgs']]] = None,
                  skip_push: Optional[pulumi.Input[bool]] = None,


### PR DESCRIPTION
We are using the Build object to create additional internal logic to discover and set changes to contextDigest and platform.
As such, it is no longer practical to keep the OneOf implementation of Build that allows for it to be a string.
The build context string will need to be passed explicitly to the Build.Context field, which provides the exact same functionality.

Fixes #428

- Remove OneOf and generate the schema
- generate SDKs
- remove string input handling from implementation
