### PR TITLE
Docs target should not depend on provider target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
 
-docs: provider
+docs:
 	cd provider/pkg/docs-gen/examples/ && \
 		PATH="$(WORKING_DIR)/bin:$$PATH" go run generate.go ./yaml ./
 


### PR DESCRIPTION
Removes circular dependency in Makefile, which prevented the schema-embed.json from being written correctly to cmd/pulumi-resource-docker in the publish step in CI.

We do not actually need for the docs build to depend on the provider build, sinc the docs are a prerequisite to generating the schema.

Fixes #545.