### PR TITLE
check for images property if cacheFrom is present

### DIFF
--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -206,15 +206,6 @@ func TestMarshalArgs(t *testing.T) {
 func TestMarshalCachedImages(t *testing.T) {
 	t.Run("Test Cached Images", func(t *testing.T) {
 		expected := []string{"apple", "banana", "cherry"}
-		imgInput := Image{
-			Name:     "unicornsareawesome",
-			SkipPush: false,
-			Registry: Registry{
-				Server:   "https://index.docker.io/v1/",
-				Username: "pulumipus",
-				Password: "supersecret",
-			},
-		}
 		buildInput := resource.NewObjectProperty(resource.PropertyMap{
 			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
 			"context":    resource.NewStringProperty("/twilight/sparkle/bin"),
@@ -227,44 +218,38 @@ func TestMarshalCachedImages(t *testing.T) {
 				}),
 			}),
 		})
-
-		actual := marshalCachedImages(imgInput, buildInput)
+		actual, err := marshalCachedImages(buildInput)
+		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 
 	})
 	t.Run("Test Cached Images No Build Input Returns Nil", func(t *testing.T) {
 		expected := []string(nil)
-		imgInput := Image{
-			Name:     "unicornsareawesome",
-			SkipPush: false,
-			Registry: Registry{
-				Server:   "https://index.docker.io/v1/",
-				Username: "pulumipus",
-				Password: "supersecret",
-			},
-		}
 		buildInput := resource.NewObjectProperty(resource.PropertyMap{})
-		actual := marshalCachedImages(imgInput, buildInput)
+		actual, err := marshalCachedImages(buildInput)
+		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
 
 	t.Run("Test Cached Images No cacheFrom Input Returns Nil", func(t *testing.T) {
 		expected := []string(nil)
-		imgInput := Image{
-			Name:     "unicornsareawesome",
-			SkipPush: false,
-			Registry: Registry{
-				Server:   "https://index.docker.io/v1/",
-				Username: "pulumipus",
-				Password: "supersecret",
-			},
-		}
 		buildInput := resource.NewObjectProperty(resource.PropertyMap{
 			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
 			"context":    resource.NewStringProperty("/twilight/sparkle/bin"),
 		})
-		actual := marshalCachedImages(imgInput, buildInput)
+		actual, err := marshalCachedImages(buildInput)
+		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
+	})
+	t.Run("Test Cached Images No images Input Returns Nil and error", func(t *testing.T) {
+		buildInput := resource.NewObjectProperty(resource.PropertyMap{
+			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
+			"context":    resource.NewStringProperty("/twilight/sparkle/bin"),
+			"cacheFrom":  resource.NewObjectProperty(resource.PropertyMap{}),
+		})
+		actual, err := marshalCachedImages(buildInput)
+		assert.Error(t, err)
+		assert.Nil(t, actual)
 	})
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"io"
 	"io/fs"
 	"os"
@@ -153,6 +154,11 @@ func (p *dockerNativeProvider) Check(ctx context.Context, req *rpc.CheckRequest)
 			if err != nil {
 				return nil, err
 			}
+		}
+
+		if _, err := marshalCachedImages(inputs["build"]); err != nil {
+			err = p.host.Log(ctx, diag.Error, urn, msg)
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-docker/issues/532

This fix avoids a panic in pkg/pulumi by verifying that the `images` property is non-null when using `cacheFrom`. It also adds verification in the `Preview` step, which avoids the user experience of discovering the error on `Update`