### PR TITLE
Restore Image.repoDigest output

### DIFF
--- a/examples/aws-container-registry/py/requirements.txt
+++ b/examples/aws-container-registry/py/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.0.0
 pulumi-aws>=5.0.0
-pulumi-docker>=3.0.0
+pulumi-docker>=4.0.0

--- a/examples/aws-container-registry/ts/index.ts
+++ b/examples/aws-container-registry/ts/index.ts
@@ -32,3 +32,4 @@ const image = new docker.Image("my-image", {
 
 // Export the resulting image name
 export const imageName = image.imageName;
+export const repoDigest = image.repoDigest;

--- a/examples/digitalocean-container-registry/py/requirements.txt
+++ b/examples/digitalocean-container-registry/py/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.0.0
 pulumi-digitalocean>=4.0.0
-pulumi-docker>=3.0.0
+pulumi-docker>=4.0.0

--- a/examples/docker-container-registry/csharp/Program.cs
+++ b/examples/docker-container-registry/csharp/Program.cs
@@ -35,6 +35,7 @@ class Program
         return new Dictionary<string, object>
         {
             { "imageName", image.ImageName },
+            { "repoDigest", image.RepoDigest },
         };
     });
 }

--- a/examples/docker-container-registry/go/main.go
+++ b/examples/docker-container-registry/go/main.go
@@ -37,6 +37,7 @@ func main() {
 
 		// Export the resulting image name and tag.
 		ctx.Export("imageName", image.ImageName)
+		ctx.Export("repoDigest", image.RepoDigest)
 		return nil
 	})
 }

--- a/examples/docker-container-registry/py/__main__.py
+++ b/examples/docker-container-registry/py/__main__.py
@@ -32,3 +32,4 @@ image = Image(
 
 # Export the resulting image name
 pulumi.export('fullImageName', image.image_name)
+pulumi.export('repoDigest', image.repo_digest)

--- a/examples/docker-container-registry/py/requirements.txt
+++ b/examples/docker-container-registry/py/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0
-pulumi-docker>=3.0.0
+pulumi-docker>=4.0.0

--- a/examples/docker-container-registry/ts/index.ts
+++ b/examples/docker-container-registry/ts/index.ts
@@ -25,3 +25,4 @@ const image = new docker.Image("my-image", {
 
 // Export the resulting image name
 export const fullImageName = image.imageName;
+export const repoDigest = image.repoDigest;

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNginxTs(t *testing.T) {
@@ -69,6 +70,11 @@ func TestAwsContainerRegistry(t *testing.T) {
 			Dir: path.Join(getCwd(t), "aws-container-registry/ts"),
 			Config: map[string]string{
 				"aws:region": region,
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				digest, ok := stack.Outputs["repoDigest"].(string)
+				assert.True(t, ok)
+				assert.NotEmpty(t, digest)
 			},
 		})
 
@@ -118,6 +124,11 @@ func TestDockerContainerRegistryNode(t *testing.T) {
 			},
 			Secrets: map[string]string{
 				"cbp-docker-ts-dev:dockerPassword": password,
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				digest, ok := stack.Outputs["repoDigest"].(string)
+				assert.True(t, ok)
+				assert.NotEmpty(t, digest)
 			},
 		})
 	integration.ProgramTest(t, &test)

--- a/examples/gcp-container-registry/py/requirements.txt
+++ b/examples/gcp-container-registry/py/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.0.0
 pulumi-gcp>=6.0.0
-pulumi-docker>=3.0.0
+pulumi-docker>=4.0.0

--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -4438,6 +4438,13 @@
                 }
             },
             "type": "object",
+            "required": [
+                "dockerfile",
+                "context",
+                "baseImageName",
+                "registryServer",
+                "imageName"
+            ],
             "inputProperties": {
                 "build": {
                     "$ref": "#/types/docker:index/dockerBuild:DockerBuild",

--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -4435,6 +4435,10 @@
                 "registryServer": {
                     "type": "string",
                     "description": "The name of the registry server hosting the image."
+                },
+                "repoDigest": {
+                    "type": "string",
+                    "description": "The digest of the manifest pushed to the registry, e.g.: repo[:tag]@\u003calgorithm\u003e:\u003chash\u003e"
                 }
             },
             "type": "object",

--- a/provider/image.go
+++ b/provider/image.go
@@ -6,6 +6,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
 	buildCmd "github.com/docker/cli/cli/command/image/build"
 	clibuild "github.com/docker/cli/cli/command/image/build"
 	"github.com/docker/cli/cli/config"
@@ -25,12 +32,6 @@ import (
 	"github.com/moby/moby/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"io"
-	"net"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 )
 
 const defaultDockerfile = "Dockerfile"
@@ -271,6 +272,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		outputs := map[string]interface{}{
 			"dockerfile":     relDockerfile,
 			"context":        img.Build.Context,
+			"baseImageName":  img.Name,
 			"registryServer": img.Registry.Server,
 			"imageName":      img.Name,
 		}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -256,6 +256,10 @@ func Provider() tfbridge.ProviderInfo {
 							Description: "The path to the build context to use.",
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 						},
+						"repoDigest": {
+							Description: "The digest of the manifest pushed to the registry, e.g.: repo[:tag]@<algorithm>:<hash>",
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+						},
 					},
 				},
 				IsComponent: false,

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -232,6 +232,9 @@ func Provider() tfbridge.ProviderInfo {
 					Type: "object",
 					Description: "Builds a Docker Image and pushes to a Docker registry.\n\n" +
 						docImage,
+					Required: []string{
+						"dockerfile", "context", "baseImageName", "registryServer", "imageName",
+					},
 					Properties: map[string]schema.PropertySpec{
 						"imageName": {
 							Description: "The fully qualified image name",

--- a/sdk/dotnet/Image.cs
+++ b/sdk/dotnet/Image.cs
@@ -47,31 +47,31 @@ namespace Pulumi.Docker
         /// The fully qualified image name that was pushed to the registry.
         /// </summary>
         [Output("baseImageName")]
-        public Output<string?> BaseImageName { get; private set; } = null!;
+        public Output<string> BaseImageName { get; private set; } = null!;
 
         /// <summary>
         /// The path to the build context to use.
         /// </summary>
         [Output("context")]
-        public Output<string?> Context { get; private set; } = null!;
+        public Output<string> Context { get; private set; } = null!;
 
         /// <summary>
         /// The location of the Dockerfile relative to the docker build context.
         /// </summary>
         [Output("dockerfile")]
-        public Output<string?> Dockerfile { get; private set; } = null!;
+        public Output<string> Dockerfile { get; private set; } = null!;
 
         /// <summary>
         /// The fully qualified image name
         /// </summary>
         [Output("imageName")]
-        public Output<string?> ImageName { get; private set; } = null!;
+        public Output<string> ImageName { get; private set; } = null!;
 
         /// <summary>
         /// The name of the registry server hosting the image.
         /// </summary>
         [Output("registryServer")]
-        public Output<string?> RegistryServer { get; private set; } = null!;
+        public Output<string> RegistryServer { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/Image.cs
+++ b/sdk/dotnet/Image.cs
@@ -73,6 +73,12 @@ namespace Pulumi.Docker
         [Output("registryServer")]
         public Output<string> RegistryServer { get; private set; } = null!;
 
+        /// <summary>
+        /// The digest of the manifest pushed to the registry, e.g.: repo[:tag]@&lt;algorithm&gt;:&lt;hash&gt;
+        /// </summary>
+        [Output("repoDigest")]
+        public Output<string?> RepoDigest { get; private set; } = null!;
+
 
         /// <summary>
         /// Create a Image resource with the given unique name, arguments, and options.

--- a/sdk/go/docker/image.go
+++ b/sdk/go/docker/image.go
@@ -48,15 +48,15 @@ type Image struct {
 	pulumi.CustomResourceState
 
 	// The fully qualified image name that was pushed to the registry.
-	BaseImageName pulumi.StringPtrOutput `pulumi:"baseImageName"`
+	BaseImageName pulumi.StringOutput `pulumi:"baseImageName"`
 	// The path to the build context to use.
-	Context pulumi.StringPtrOutput `pulumi:"context"`
+	Context pulumi.StringOutput `pulumi:"context"`
 	// The location of the Dockerfile relative to the docker build context.
-	Dockerfile pulumi.StringPtrOutput `pulumi:"dockerfile"`
+	Dockerfile pulumi.StringOutput `pulumi:"dockerfile"`
 	// The fully qualified image name
-	ImageName pulumi.StringPtrOutput `pulumi:"imageName"`
+	ImageName pulumi.StringOutput `pulumi:"imageName"`
 	// The name of the registry server hosting the image.
-	RegistryServer pulumi.StringPtrOutput `pulumi:"registryServer"`
+	RegistryServer pulumi.StringOutput `pulumi:"registryServer"`
 }
 
 // NewImage registers a new resource with the given unique name, arguments, and options.
@@ -223,28 +223,28 @@ func (o ImageOutput) ToImageOutputWithContext(ctx context.Context) ImageOutput {
 }
 
 // The fully qualified image name that was pushed to the registry.
-func (o ImageOutput) BaseImageName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Image) pulumi.StringPtrOutput { return v.BaseImageName }).(pulumi.StringPtrOutput)
+func (o ImageOutput) BaseImageName() pulumi.StringOutput {
+	return o.ApplyT(func(v *Image) pulumi.StringOutput { return v.BaseImageName }).(pulumi.StringOutput)
 }
 
 // The path to the build context to use.
-func (o ImageOutput) Context() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Image) pulumi.StringPtrOutput { return v.Context }).(pulumi.StringPtrOutput)
+func (o ImageOutput) Context() pulumi.StringOutput {
+	return o.ApplyT(func(v *Image) pulumi.StringOutput { return v.Context }).(pulumi.StringOutput)
 }
 
 // The location of the Dockerfile relative to the docker build context.
-func (o ImageOutput) Dockerfile() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Image) pulumi.StringPtrOutput { return v.Dockerfile }).(pulumi.StringPtrOutput)
+func (o ImageOutput) Dockerfile() pulumi.StringOutput {
+	return o.ApplyT(func(v *Image) pulumi.StringOutput { return v.Dockerfile }).(pulumi.StringOutput)
 }
 
 // The fully qualified image name
-func (o ImageOutput) ImageName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Image) pulumi.StringPtrOutput { return v.ImageName }).(pulumi.StringPtrOutput)
+func (o ImageOutput) ImageName() pulumi.StringOutput {
+	return o.ApplyT(func(v *Image) pulumi.StringOutput { return v.ImageName }).(pulumi.StringOutput)
 }
 
 // The name of the registry server hosting the image.
-func (o ImageOutput) RegistryServer() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Image) pulumi.StringPtrOutput { return v.RegistryServer }).(pulumi.StringPtrOutput)
+func (o ImageOutput) RegistryServer() pulumi.StringOutput {
+	return o.ApplyT(func(v *Image) pulumi.StringOutput { return v.RegistryServer }).(pulumi.StringOutput)
 }
 
 type ImageArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/docker/image.go
+++ b/sdk/go/docker/image.go
@@ -57,6 +57,8 @@ type Image struct {
 	ImageName pulumi.StringOutput `pulumi:"imageName"`
 	// The name of the registry server hosting the image.
 	RegistryServer pulumi.StringOutput `pulumi:"registryServer"`
+	// The digest of the manifest pushed to the registry, e.g.: repo[:tag]@<algorithm>:<hash>
+	RepoDigest pulumi.StringPtrOutput `pulumi:"repoDigest"`
 }
 
 // NewImage registers a new resource with the given unique name, arguments, and options.
@@ -245,6 +247,11 @@ func (o ImageOutput) ImageName() pulumi.StringOutput {
 // The name of the registry server hosting the image.
 func (o ImageOutput) RegistryServer() pulumi.StringOutput {
 	return o.ApplyT(func(v *Image) pulumi.StringOutput { return v.RegistryServer }).(pulumi.StringOutput)
+}
+
+// The digest of the manifest pushed to the registry, e.g.: repo[:tag]@<algorithm>:<hash>
+func (o ImageOutput) RepoDigest() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Image) pulumi.StringPtrOutput { return v.RepoDigest }).(pulumi.StringPtrOutput)
 }
 
 type ImageArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/docker/Image.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/Image.java
@@ -12,6 +12,7 @@ import com.pulumi.docker.ImageArgs;
 import com.pulumi.docker.Utilities;
 import java.lang.String;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -127,6 +128,20 @@ public class Image extends com.pulumi.resources.CustomResource {
      */
     public Output<String> registryServer() {
         return this.registryServer;
+    }
+    /**
+     * The digest of the manifest pushed to the registry, e.g.: repo[:tag]@&lt;algorithm&gt;:&lt;hash&gt;
+     * 
+     */
+    @Export(name="repoDigest", type=String.class, parameters={})
+    private Output</* @Nullable */ String> repoDigest;
+
+    /**
+     * @return The digest of the manifest pushed to the registry, e.g.: repo[:tag]@&lt;algorithm&gt;:&lt;hash&gt;
+     * 
+     */
+    public Output<Optional<String>> repoDigest() {
+        return Codegen.optional(this.repoDigest);
     }
 
     /**

--- a/sdk/java/src/main/java/com/pulumi/docker/Image.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/Image.java
@@ -12,7 +12,6 @@ import com.pulumi.docker.ImageArgs;
 import com.pulumi.docker.Utilities;
 import java.lang.String;
 import java.util.List;
-import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -64,70 +63,70 @@ public class Image extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="baseImageName", type=String.class, parameters={})
-    private Output</* @Nullable */ String> baseImageName;
+    private Output<String> baseImageName;
 
     /**
      * @return The fully qualified image name that was pushed to the registry.
      * 
      */
-    public Output<Optional<String>> baseImageName() {
-        return Codegen.optional(this.baseImageName);
+    public Output<String> baseImageName() {
+        return this.baseImageName;
     }
     /**
      * The path to the build context to use.
      * 
      */
     @Export(name="context", type=String.class, parameters={})
-    private Output</* @Nullable */ String> context;
+    private Output<String> context;
 
     /**
      * @return The path to the build context to use.
      * 
      */
-    public Output<Optional<String>> context() {
-        return Codegen.optional(this.context);
+    public Output<String> context() {
+        return this.context;
     }
     /**
      * The location of the Dockerfile relative to the docker build context.
      * 
      */
     @Export(name="dockerfile", type=String.class, parameters={})
-    private Output</* @Nullable */ String> dockerfile;
+    private Output<String> dockerfile;
 
     /**
      * @return The location of the Dockerfile relative to the docker build context.
      * 
      */
-    public Output<Optional<String>> dockerfile() {
-        return Codegen.optional(this.dockerfile);
+    public Output<String> dockerfile() {
+        return this.dockerfile;
     }
     /**
      * The fully qualified image name
      * 
      */
     @Export(name="imageName", type=String.class, parameters={})
-    private Output</* @Nullable */ String> imageName;
+    private Output<String> imageName;
 
     /**
      * @return The fully qualified image name
      * 
      */
-    public Output<Optional<String>> imageName() {
-        return Codegen.optional(this.imageName);
+    public Output<String> imageName() {
+        return this.imageName;
     }
     /**
      * The name of the registry server hosting the image.
      * 
      */
     @Export(name="registryServer", type=String.class, parameters={})
-    private Output</* @Nullable */ String> registryServer;
+    private Output<String> registryServer;
 
     /**
      * @return The name of the registry server hosting the image.
      * 
      */
-    public Output<Optional<String>> registryServer() {
-        return Codegen.optional(this.registryServer);
+    public Output<String> registryServer() {
+        return this.registryServer;
     }
 
     /**

--- a/sdk/nodejs/image.ts
+++ b/sdk/nodejs/image.ts
@@ -58,23 +58,23 @@ export class Image extends pulumi.CustomResource {
     /**
      * The fully qualified image name that was pushed to the registry.
      */
-    public /*out*/ readonly baseImageName!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly baseImageName!: pulumi.Output<string>;
     /**
      * The path to the build context to use.
      */
-    public /*out*/ readonly context!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly context!: pulumi.Output<string>;
     /**
      * The location of the Dockerfile relative to the docker build context.
      */
-    public /*out*/ readonly dockerfile!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly dockerfile!: pulumi.Output<string>;
     /**
      * The fully qualified image name
      */
-    public readonly imageName!: pulumi.Output<string | undefined>;
+    public readonly imageName!: pulumi.Output<string>;
     /**
      * The name of the registry server hosting the image.
      */
-    public /*out*/ readonly registryServer!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly registryServer!: pulumi.Output<string>;
 
     /**
      * Create a Image resource with the given unique name, arguments, and options.

--- a/sdk/nodejs/image.ts
+++ b/sdk/nodejs/image.ts
@@ -75,6 +75,10 @@ export class Image extends pulumi.CustomResource {
      * The name of the registry server hosting the image.
      */
     public /*out*/ readonly registryServer!: pulumi.Output<string>;
+    /**
+     * The digest of the manifest pushed to the registry, e.g.: repo[:tag]@<algorithm>:<hash>
+     */
+    public /*out*/ readonly repoDigest!: pulumi.Output<string | undefined>;
 
     /**
      * Create a Image resource with the given unique name, arguments, and options.
@@ -98,12 +102,14 @@ export class Image extends pulumi.CustomResource {
             resourceInputs["context"] = undefined /*out*/;
             resourceInputs["dockerfile"] = undefined /*out*/;
             resourceInputs["registryServer"] = undefined /*out*/;
+            resourceInputs["repoDigest"] = undefined /*out*/;
         } else {
             resourceInputs["baseImageName"] = undefined /*out*/;
             resourceInputs["context"] = undefined /*out*/;
             resourceInputs["dockerfile"] = undefined /*out*/;
             resourceInputs["imageName"] = undefined /*out*/;
             resourceInputs["registryServer"] = undefined /*out*/;
+            resourceInputs["repoDigest"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const aliasOpts = { aliases: [{ type: "docker:image:Image" }] };

--- a/sdk/python/pulumi_docker/image.py
+++ b/sdk/python/pulumi_docker/image.py
@@ -220,7 +220,7 @@ class Image(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="baseImageName")
-    def base_image_name(self) -> pulumi.Output[Optional[str]]:
+    def base_image_name(self) -> pulumi.Output[str]:
         """
         The fully qualified image name that was pushed to the registry.
         """
@@ -228,7 +228,7 @@ class Image(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def context(self) -> pulumi.Output[Optional[str]]:
+    def context(self) -> pulumi.Output[str]:
         """
         The path to the build context to use.
         """
@@ -236,7 +236,7 @@ class Image(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def dockerfile(self) -> pulumi.Output[Optional[str]]:
+    def dockerfile(self) -> pulumi.Output[str]:
         """
         The location of the Dockerfile relative to the docker build context.
         """
@@ -244,7 +244,7 @@ class Image(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="imageName")
-    def image_name(self) -> pulumi.Output[Optional[str]]:
+    def image_name(self) -> pulumi.Output[str]:
         """
         The fully qualified image name
         """
@@ -252,7 +252,7 @@ class Image(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="registryServer")
-    def registry_server(self) -> pulumi.Output[Optional[str]]:
+    def registry_server(self) -> pulumi.Output[str]:
         """
         The name of the registry server hosting the image.
         """

--- a/sdk/python/pulumi_docker/image.py
+++ b/sdk/python/pulumi_docker/image.py
@@ -187,6 +187,7 @@ class Image(pulumi.CustomResource):
             __props__.__dict__["context"] = None
             __props__.__dict__["dockerfile"] = None
             __props__.__dict__["registry_server"] = None
+            __props__.__dict__["repo_digest"] = None
         alias_opts = pulumi.ResourceOptions(aliases=[pulumi.Alias(type_="docker:image:Image")])
         opts = pulumi.ResourceOptions.merge(opts, alias_opts)
         super(Image, __self__).__init__(
@@ -216,6 +217,7 @@ class Image(pulumi.CustomResource):
         __props__.__dict__["dockerfile"] = None
         __props__.__dict__["image_name"] = None
         __props__.__dict__["registry_server"] = None
+        __props__.__dict__["repo_digest"] = None
         return Image(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -257,4 +259,12 @@ class Image(pulumi.CustomResource):
         The name of the registry server hosting the image.
         """
         return pulumi.get(self, "registry_server")
+
+    @property
+    @pulumi.getter(name="repoDigest")
+    def repo_digest(self) -> pulumi.Output[Optional[str]]:
+        """
+        The digest of the manifest pushed to the registry, e.g.: repo[:tag]@<algorithm>:<hash>
+        """
+        return pulumi.get(self, "repo_digest")
 


### PR DESCRIPTION
The Image.repoDigest property was removed in v4 as part of the transition to use the Docker SDK instead of the Docker CLI. Fortunately the SDK exposes a method that makes it easy to construct the repo digest.

Fix https://github.com/pulumi/pulumi-docker/issues/507.

Copied from #540 to run tests.