### PR TITLE
Read docker host from config

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -700,7 +700,6 @@ func configureDockerClient(configs map[string]string) (*client.Client, error) {
 		return client.NewClientWithOpts(
 			client.WithHTTPClient(httpClient),
 			client.FromEnv,
-			client.WithHost(host),
 			client.WithAPIVersionNegotiation(),
 		)
 	}

--- a/provider/image.go
+++ b/provider/image.go
@@ -689,6 +689,14 @@ func configureDockerClient(configs map[string]string) (*client.Client, error) {
 		}
 
 		// Set custom client first
+		if host != "" {
+			return client.NewClientWithOpts(
+				client.WithHTTPClient(httpClient),
+				client.WithHost(host),
+				client.FromEnv,
+				client.WithAPIVersionNegotiation(),
+			)
+		}
 		return client.NewClientWithOpts(
 			client.WithHTTPClient(httpClient),
 			client.FromEnv,
@@ -703,6 +711,14 @@ func configureDockerClient(configs map[string]string) (*client.Client, error) {
 		ca = filepath.Join(certPath, "ca.pem")
 		cert = filepath.Join(certPath, "cert.pem")
 		key = filepath.Join(certPath, "key.pem")
+		if host != "" {
+			return client.NewClientWithOpts(
+				client.FromEnv,
+				client.WithHost(host),
+				client.WithTLSClientConfig(ca, cert, key),
+				client.WithAPIVersionNegotiation(),
+			)
+		}
 		return client.NewClientWithOpts(
 			client.FromEnv,
 			client.WithTLSClientConfig(ca, cert, key),
@@ -711,6 +727,14 @@ func configureDockerClient(configs map[string]string) (*client.Client, error) {
 	}
 
 	// No TLS certificate material provided, create an http client
+	if host != "" {
+		return client.NewClientWithOpts(
+			client.FromEnv,
+			client.WithHost(host),
+			client.WithAPIVersionNegotiation(),
+		)
+	}
+
 	return client.NewClientWithOpts(
 		client.FromEnv,
 		client.WithAPIVersionNegotiation(),


### PR DESCRIPTION
Because Image is part of the native provider, we need to be able to pass configurations to it as well. This change allows users to set the hostname for the docker host in their configuration file.

Fixes #567.
Closes #51 as well.