### PR TITLE
Skip unknowns in Check to avoid panic when marshalling Build object

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -137,6 +137,21 @@ func TestDockerContainerRegistryNode(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestUnknownInputsNode(t *testing.T) {
+	test := getJsOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "test-unknowns", "ts"),
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				randID, ok := stack.Outputs["randnameid"]
+				assert.True(t, ok)
+				assert.NotEmpty(t, randID)
+			},
+			Quick:       true,
+			SkipRefresh: true,
+		})
+	integration.ProgramTest(t, &test)
+}
+
 func getJsOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions()
 	baseJs := base.With(integration.ProgramTestOptions{

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -1,0 +1,42 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build go || all
+// +build go all
+
+package examples
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestUnknownInputsYAML(t *testing.T) {
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:         path.Join(cwd, "test-unknowns", "yaml"),
+		Quick:       true,
+		SkipRefresh: true,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			randID, ok := stack.Outputs["randNameId"]
+			assert.True(t, ok)
+			assert.NotEmpty(t, randID)
+		},
+	})
+}

--- a/examples/test-unknowns/ts/Dockerfile
+++ b/examples/test-unknowns/ts/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu AS base
+RUN echo "base"
+
+FROM base AS stage1
+RUN echo "stage1"
+
+FROM base AS stage2
+RUN echo "stage2"

--- a/examples/test-unknowns/ts/Pulumi.yaml
+++ b/examples/test-unknowns/ts/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: test-unknowns
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/examples/test-unknowns/ts/index.ts
+++ b/examples/test-unknowns/ts/index.ts
@@ -1,0 +1,23 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as docker from "@pulumi/docker";
+import * as random from "@pulumi/random";
+
+
+
+const randName = new random.RandomString("random", {
+    length: 10,
+
+});
+
+const img = new docker.Image("docker-565-one", {
+    imageName: "pulumibot/test-image:with-build-args",
+
+    build: {
+        args: {
+            "RANDOM_ARG": randName.id
+        },
+    },
+    skipPush: true,
+});
+
+export const randnameid = randName.id

--- a/examples/test-unknowns/ts/package.json
+++ b/examples/test-unknowns/ts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-unknowns",
+  "devDependencies": {
+    "@types/node": "^14.0.0"
+  },
+  "dependencies": {
+    "@pulumi/docker": "^4.1.0",
+    "@pulumi/random": "^4.12.1",
+    "@pulumi/pulumi": "^3.0.0"
+  }
+}

--- a/examples/test-unknowns/ts/tsconfig.json
+++ b/examples/test-unknowns/ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2016",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}

--- a/examples/test-unknowns/yaml/Dockerfile
+++ b/examples/test-unknowns/yaml/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu AS base
+RUN echo "base"
+
+FROM base AS stage1
+RUN echo "stage1"
+
+FROM base AS stage2
+RUN echo "stage2"

--- a/examples/test-unknowns/yaml/Pulumi.yaml
+++ b/examples/test-unknowns/yaml/Pulumi.yaml
@@ -1,0 +1,19 @@
+name: dockerfile-default-context
+runtime: yaml
+resources:
+  randName:
+    type: random:RandomString
+    properties:
+      length: 8
+  demo-image:
+    type: docker:Image
+    properties:
+      imageName: pulumibot/test-unknowns:yaml
+      skipPush: true
+      build:
+        args:
+          RANDOM_ARG: ${randName.id}
+    options:
+      version: v4.1.0
+outputs:
+  randNameId: ${randName.id}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -109,7 +109,7 @@ func (p *dockerNativeProvider) Check(ctx context.Context, req *rpc.CheckRequest)
 	logging.V(9).Infof("%s executing", label)
 
 	inputs, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{
-		KeepUnknowns: true,
+		KeepUnknowns: false,
 		SkipNulls:    true,
 		KeepSecrets:  true,
 	})


### PR DESCRIPTION
When we try to access a Build object which contains unknown values in the Check() function, the provider panics, because the Build object is not of the correct resource type.
This pull request ignores unknowns when reading inputs in Check(), allowing for the resulting object to be processed correctly.
Fixes #565.
