### PR TITLE
fix: return reasonable errors for cache marshaling and allow for unknowns to pass through

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -422,7 +422,7 @@ func marshalCachedImages(b resource.PropertyValue) ([]string, error) {
 		return cacheImages, fmt.Errorf("cacheFrom requires an `images` field")
 	}
 	if !cacheFrom["images"].IsArray() {
-		return cacheImages, fmt.Errorf("the `images` field must be a list of items")
+		return cacheImages, fmt.Errorf("the `images` field must be a list of strings")
 	}
 
 	stages := cacheFrom["images"].ArrayValue()

--- a/provider/image.go
+++ b/provider/image.go
@@ -419,10 +419,18 @@ func marshalCachedImages(b resource.PropertyValue) ([]string, error) {
 	// if we specify a list of stages, then we only pull those
 	cacheFrom := c.ObjectValue()
 	if cacheFrom["images"].IsNull() {
-		return cacheImages, fmt.Errorf("if you want to use cacheFrom, you must have `images` set")
+		return cacheImages, fmt.Errorf("cacheFrom requires an `images` field")
 	}
+	if !cacheFrom["images"].IsArray() {
+		return cacheImages, fmt.Errorf("the `images` field must be a list of items")
+	}
+
 	stages := cacheFrom["images"].ArrayValue()
 	for _, img := range stages {
+		// if we are in preview, we cannot add an undefined Output so we skip to the next item
+		if img.IsNull() {
+			continue
+		}
 		stage := img.StringValue()
 		cacheImages = append(cacheImages, stage)
 	}

--- a/provider/image.go
+++ b/provider/image.go
@@ -418,17 +418,18 @@ func marshalCachedImages(b resource.PropertyValue) ([]string, error) {
 
 	// if we specify a list of stages, then we only pull those
 	cacheFrom := c.ObjectValue()
-	if _, ok := cacheFrom["images"]; !ok {
+	images, ok := cacheFrom["images"]
+	if !ok {
 		return cacheImages, fmt.Errorf("cacheFrom requires an `images` field")
 	}
-	if cacheFrom["images"].IsNull() {
+	if images.IsNull() {
 		return cacheImages, nil
 	}
-	if !cacheFrom["images"].IsArray() {
+	if !images.IsArray() {
 		return cacheImages, fmt.Errorf("the `images` field must be a list of strings")
 	}
 
-	stages := cacheFrom["images"].ArrayValue()
+	stages := images.ArrayValue()
 	for _, img := range stages {
 		// if we are in preview, we cannot add an undefined Output so we skip to the next item
 		if img.IsNull() {

--- a/provider/image.go
+++ b/provider/image.go
@@ -418,8 +418,11 @@ func marshalCachedImages(b resource.PropertyValue) ([]string, error) {
 
 	// if we specify a list of stages, then we only pull those
 	cacheFrom := c.ObjectValue()
-	if cacheFrom["images"].IsNull() {
+	if _, ok := cacheFrom["images"]; !ok {
 		return cacheImages, fmt.Errorf("cacheFrom requires an `images` field")
+	}
+	if cacheFrom["images"].IsNull() {
+		return cacheImages, nil
 	}
 	if !cacheFrom["images"].IsArray() {
 		return cacheImages, fmt.Errorf("the `images` field must be a list of strings")

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -305,6 +305,26 @@ func TestMarshalCachedImages(t *testing.T) {
 		assert.Equal(t, expected, actual)
 
 	})
+	t.Run("Test Cached Images Passes On Unknown Images List", func(t *testing.T) {
+		expected := []string(nil)
+		buildInput := resource.NewObjectProperty(resource.PropertyMap{
+			"cacheFrom": resource.NewObjectProperty(resource.PropertyMap{
+				"images": resource.NewNullProperty(), // unknowns are passed as null property values
+			}),
+		})
+		actual, err := marshalCachedImages(buildInput)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Test Cached Images Passes On Unknown cacheFrom", func(t *testing.T) {
+		expected := []string(nil)
+		buildInput := resource.NewObjectProperty(resource.PropertyMap{
+			"cacheFrom": resource.NewNullProperty(), // unknowns are passed as null property values
+		})
+		actual, err := marshalCachedImages(buildInput)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
 }
 
 func TestMarshalBuilder(t *testing.T) {

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -251,7 +251,7 @@ func TestMarshalCachedImages(t *testing.T) {
 			}),
 		})
 		actual, err := marshalCachedImages(buildInput)
-		expectedError := fmt.Errorf("the `images` field must be a list of items")
+		expectedError := fmt.Errorf("the `images` field must be a list of strings")
 		if assert.Error(t, err) {
 			assert.Equal(t, expectedError, err)
 		}

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -241,6 +241,23 @@ func TestMarshalCachedImages(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
+	t.Run("Test Cached Images Non-array Images Returns Nil and Error", func(t *testing.T) {
+		expected := []string(nil)
+		buildInput := resource.NewObjectProperty(resource.PropertyMap{
+			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
+			"context":    resource.NewStringProperty("/twilight/sparkle/bin"),
+			"cacheFrom": resource.NewObjectProperty(resource.PropertyMap{
+				"images": resource.NewStringProperty("Shadowfax"),
+			}),
+		})
+		actual, err := marshalCachedImages(buildInput)
+		expectedError := fmt.Errorf("the `images` field must be a list of items")
+		if assert.Error(t, err) {
+			assert.Equal(t, expectedError, err)
+		}
+		assert.Equal(t, expected, actual)
+		assert.Nil(t, actual)
+	})
 	t.Run("Test Cached Images No images Input Returns Nil and error", func(t *testing.T) {
 		buildInput := resource.NewObjectProperty(resource.PropertyMap{
 			"dockerfile": resource.NewStringProperty("TheLastUnicorn"),
@@ -248,8 +265,45 @@ func TestMarshalCachedImages(t *testing.T) {
 			"cacheFrom":  resource.NewObjectProperty(resource.PropertyMap{}),
 		})
 		actual, err := marshalCachedImages(buildInput)
-		assert.Error(t, err)
+		expectedError := fmt.Errorf("cacheFrom requires an `images` field")
+		if assert.Error(t, err) {
+			assert.Equal(t, expectedError, err)
+		}
 		assert.Nil(t, actual)
+	})
+
+	t.Run("Test Cached Images Passes On Unknowns", func(t *testing.T) {
+		expected := []string(nil)
+		buildInput := resource.NewObjectProperty(resource.PropertyMap{
+
+			"cacheFrom": resource.NewObjectProperty(resource.PropertyMap{
+				"images": resource.NewArrayProperty([]resource.PropertyValue{
+					resource.NewNullProperty(), // unknowns are passed as null property values
+				}),
+			}),
+		})
+		actual, err := marshalCachedImages(buildInput)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+
+	})
+	t.Run("Test Cached Images For Preview Passes On Unknowns And Keeps Knowns", func(t *testing.T) {
+		expected := []string{"apple", "banana", "cherry"}
+		buildInput := resource.NewObjectProperty(resource.PropertyMap{
+
+			"cacheFrom": resource.NewObjectProperty(resource.PropertyMap{
+				"images": resource.NewArrayProperty([]resource.PropertyValue{
+					resource.NewNullProperty(),
+					resource.NewStringProperty("apple"),
+					resource.NewStringProperty("banana"),
+					resource.NewStringProperty("cherry"),
+				}),
+			}),
+		})
+		actual, err := marshalCachedImages(buildInput)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+
 	})
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"io"
 	"io/fs"
 	"os"
@@ -195,8 +194,10 @@ func (p *dockerNativeProvider) Check(ctx context.Context, req *rpc.CheckRequest)
 			}
 		}
 
-		if _, err := marshalCachedImages(inputs["build"]); err != nil {
-			err = p.host.Log(ctx, diag.Error, urn, msg)
+	}
+	if _, err = marshalCachedImages(inputs["build"]); err != nil {
+
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -206,7 +207,6 @@ func (p *dockerNativeProvider) Check(ctx context.Context, req *rpc.CheckRequest)
 		SkipNulls:    true,
 		KeepSecrets:  true,
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -196,10 +196,7 @@ func (p *dockerNativeProvider) Check(ctx context.Context, req *rpc.CheckRequest)
 
 	}
 	if _, err = marshalCachedImages(inputs["build"]); err != nil {
-
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	inputStruct, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{


### PR DESCRIPTION
In #555 we addressed a panic for an empty `cacheFrom` object.
We added a verificaton step at the Check() function to fail early.
This introduced a panic created by passing unknowns to marshalCachedImages.
This pull request refines the logic in the marshalling function to handle unknowns, catches possible panics via returning a helpful error, and adds tests for these additional scenarios.
Fixes #576.

- Improve error messaging for input verification when called during Check() Move verification to its own if block
- Add tests to verify cacheFrom marshaling
