### PR TITLE
Support additional .dockerignore formats

### DIFF
--- a/examples/dockerfile_test.go
+++ b/examples/dockerfile_test.go
@@ -141,9 +141,5 @@ func TestDockerignoreWithExternalDockerfileYAML(t *testing.T) {
 		Dir:         path.Join(cwd, "test-dockerfile", "dockerignore-with-external-dockerfile"),
 		Quick:       true,
 		SkipRefresh: true,
-		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-			expected := " BOOYAH"
-			assert.Equal(t, expected, stack.Outputs)
-		},
 	})
 }

--- a/examples/dockerfile_test.go
+++ b/examples/dockerfile_test.go
@@ -75,3 +75,75 @@ func TestDockerfileInContextYAML(t *testing.T) {
 		SkipRefresh: true,
 	})
 }
+
+func TestDockerignoreDefaultYAML(t *testing.T) {
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:         path.Join(cwd, "test-dockerfile", "dockerignore-default"),
+		Quick:       true,
+		SkipRefresh: true,
+	})
+}
+
+func TestDockerignoreSpecifiedYAML(t *testing.T) {
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:         path.Join(cwd, "test-dockerfile", "dockerignore-specified"),
+		Quick:       true,
+		SkipRefresh: true,
+	})
+}
+
+func TestDockerignoreDefaultFailYAML(t *testing.T) {
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:           path.Join(cwd, "test-dockerfile", "dockerignore-default-fail"),
+		Quick:         true,
+		SkipRefresh:   true,
+		ExpectFailure: true,
+	})
+}
+
+func TestDockerignoreNoMappingYAML(t *testing.T) {
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	// we expect this test to succeed, as we test that the ignore.txt file does in fact _not_ get ignored
+	// the ignore.txt file does not get ignored, as  .dockerignore does not map to Mockerfile.
+	// The RUN command in Mockerfile therefore succeeds.
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:         path.Join(cwd, "test-dockerfile", "dockerignore-no-mapping"),
+		Quick:       true,
+		SkipRefresh: true,
+	})
+}
+
+func TestDockerignoreWithExternalDockerfileYAML(t *testing.T) {
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:         path.Join(cwd, "test-dockerfile", "dockerignore-with-external-dockerfile"),
+		Quick:       true,
+		SkipRefresh: true,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			expected := " BOOYAH"
+			assert.Equal(t, expected, stack.Outputs)
+		},
+	})
+}

--- a/examples/test-dockerfile/dockerignore-default-fail/.dockerignore
+++ b/examples/test-dockerfile/dockerignore-default-fail/.dockerignore
@@ -1,0 +1,1 @@
+ignore.txt

--- a/examples/test-dockerfile/dockerignore-default-fail/Dockerfile
+++ b/examples/test-dockerfile/dockerignore-default-fail/Dockerfile
@@ -1,0 +1,8 @@
+FROM --platform=linux/amd64 ubuntu
+
+COPY . /
+
+RUN cat app.txt
+
+Run cat ignore.txt
+

--- a/examples/test-dockerfile/dockerignore-default-fail/Pulumi.yaml
+++ b/examples/test-dockerfile/dockerignore-default-fail/Pulumi.yaml
@@ -1,0 +1,13 @@
+name: dockerfile-default
+runtime: yaml
+resources:
+  demo-image:
+    type: docker:Image
+    properties:
+      imageName: pulumibot/ignore-image:tag2
+      skipPush: true
+    options:
+      version: v4.0.0
+outputs:
+  imageName: ${demo-image.imageName}
+  out-dockerfile: ${demo-image.dockerfile}

--- a/examples/test-dockerfile/dockerignore-default-fail/app.txt
+++ b/examples/test-dockerfile/dockerignore-default-fail/app.txt
@@ -1,0 +1,1 @@
+Hi! I am a test file!

--- a/examples/test-dockerfile/dockerignore-default-fail/ignore.txt
+++ b/examples/test-dockerfile/dockerignore-default-fail/ignore.txt
@@ -1,0 +1,1 @@
+Hi! I should get ignored!

--- a/examples/test-dockerfile/dockerignore-default/.dockerignore
+++ b/examples/test-dockerfile/dockerignore-default/.dockerignore
@@ -1,0 +1,1 @@
+ignore.txt

--- a/examples/test-dockerfile/dockerignore-default/Dockerfile
+++ b/examples/test-dockerfile/dockerignore-default/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY . /

--- a/examples/test-dockerfile/dockerignore-default/Pulumi.yaml
+++ b/examples/test-dockerfile/dockerignore-default/Pulumi.yaml
@@ -1,0 +1,13 @@
+name: dockerfile-default
+runtime: yaml
+resources:
+  demo-image:
+    type: docker:Image
+    properties:
+      imageName: pulumibot/ignore-image:tag1
+      skipPush: true
+    options:
+      version: v4.0.0
+outputs:
+  imageName: ${demo-image.imageName}
+  out-dockerfile: ${demo-image.dockerfile}

--- a/examples/test-dockerfile/dockerignore-default/app.txt
+++ b/examples/test-dockerfile/dockerignore-default/app.txt
@@ -1,0 +1,1 @@
+Hi! I am a test file!

--- a/examples/test-dockerfile/dockerignore-default/ignore.txt
+++ b/examples/test-dockerfile/dockerignore-default/ignore.txt
@@ -1,0 +1,1 @@
+Hi! I should get ignored!

--- a/examples/test-dockerfile/dockerignore-no-mapping/.dockerignore
+++ b/examples/test-dockerfile/dockerignore-no-mapping/.dockerignore
@@ -1,0 +1,1 @@
+ignore.txt

--- a/examples/test-dockerfile/dockerignore-no-mapping/Mockerfile
+++ b/examples/test-dockerfile/dockerignore-no-mapping/Mockerfile
@@ -1,0 +1,7 @@
+FROM --platform=linux/amd64 ubuntu
+
+COPY . /
+
+Run cat app.txt
+
+RUN cat ignore.txt

--- a/examples/test-dockerfile/dockerignore-no-mapping/Pulumi.yaml
+++ b/examples/test-dockerfile/dockerignore-no-mapping/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: dockerfile-default
+runtime: yaml
+resources:
+  demo-image:
+    type: docker:Image
+    properties:
+      imageName: pulumibot/ignore-image:tag4
+      skipPush: true
+      build:
+        context: .
+        dockerfile: Mockerfile
+    options:
+      version: v4.0.0
+outputs:
+  imageName: ${demo-image.imageName}
+  out-dockerfile: ${demo-image.dockerfile}

--- a/examples/test-dockerfile/dockerignore-no-mapping/app.txt
+++ b/examples/test-dockerfile/dockerignore-no-mapping/app.txt
@@ -1,0 +1,1 @@
+Hi! I am a test file!

--- a/examples/test-dockerfile/dockerignore-no-mapping/ignore.txt
+++ b/examples/test-dockerfile/dockerignore-no-mapping/ignore.txt
@@ -1,0 +1,1 @@
+Hi! I should get ignored!

--- a/examples/test-dockerfile/dockerignore-specified/Mockerfile
+++ b/examples/test-dockerfile/dockerignore-specified/Mockerfile
@@ -1,0 +1,3 @@
+FROM --platform=linux/amd64 ubuntu
+
+COPY . /

--- a/examples/test-dockerfile/dockerignore-specified/Mockerfile.dockerignore
+++ b/examples/test-dockerfile/dockerignore-specified/Mockerfile.dockerignore
@@ -1,0 +1,1 @@
+ignore.txt

--- a/examples/test-dockerfile/dockerignore-specified/Pulumi.yaml
+++ b/examples/test-dockerfile/dockerignore-specified/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: dockerfile-default
+runtime: yaml
+resources:
+  demo-image:
+    type: docker:Image
+    properties:
+      imageName: pulumibot/ignore-image:tag3
+      skipPush: true
+      build:
+        context: .
+        dockerfile: Mockerfile
+    options:
+      version: v4.0.0
+outputs:
+  imageName: ${demo-image.imageName}
+  out-dockerfile: ${demo-image.dockerfile}

--- a/examples/test-dockerfile/dockerignore-specified/app.txt
+++ b/examples/test-dockerfile/dockerignore-specified/app.txt
@@ -1,0 +1,1 @@
+Hi! I am a test file!

--- a/examples/test-dockerfile/dockerignore-specified/ignore.txt
+++ b/examples/test-dockerfile/dockerignore-specified/ignore.txt
@@ -1,0 +1,1 @@
+Hi! I should get ignored!

--- a/examples/test-dockerfile/dockerignore-with-external-dockerfile/Dockerfile
+++ b/examples/test-dockerfile/dockerignore-with-external-dockerfile/Dockerfile
@@ -1,0 +1,5 @@
+FROM --platform=linux/amd64 ubuntu
+
+COPY . /
+
+RUN cat app.txt

--- a/examples/test-dockerfile/dockerignore-with-external-dockerfile/Pulumi.yaml
+++ b/examples/test-dockerfile/dockerignore-with-external-dockerfile/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: dockerfile-external
+runtime: yaml
+resources:
+  demo-image:
+    type: docker:Image
+    properties:
+      imageName: pulumibot/test-image:tag3
+      skipPush: true
+      build:
+        context: ./app
+        dockerfile: ./Dockerfile
+    options:
+      version: v4.0.0
+outputs:
+  imageName: ${demo-image.imageName}
+  out-dockerfile: ${demo-image.dockerfile}

--- a/examples/test-dockerfile/dockerignore-with-external-dockerfile/app/.dockerignore
+++ b/examples/test-dockerfile/dockerignore-with-external-dockerfile/app/.dockerignore
@@ -1,0 +1,1 @@
+ignore.txt

--- a/examples/test-dockerfile/dockerignore-with-external-dockerfile/app/app.txt
+++ b/examples/test-dockerfile/dockerignore-with-external-dockerfile/app/app.txt
@@ -1,0 +1,1 @@
+Hi! I am a test file!

--- a/provider/image.go
+++ b/provider/image.go
@@ -819,7 +819,7 @@ func mapDockerignore(dockerfile string) string {
 	ignore := ".dockerignore"
 
 	// Add extension for nonstandardly named Dockerfiles
-	if dockerfile != "Dockerfile" {
+	if dockerfile != defaultDockerfile {
 		ignore = dockerfile + ignore
 	}
 	// Return the default dockerignore name.

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -497,3 +497,20 @@ func TestConfigureDockerClient(t *testing.T) {
 	})
 
 }
+
+func TestMapDockerignore(t *testing.T) {
+
+	t.Run("Returns default .dockerignore", func(t *testing.T) {
+		expected := ".dockerignore"
+		input := "Dockerfile"
+		actual := mapDockerignore(input)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Returns .dockerignore extension for nonstandard dockerfile names", func(t *testing.T) {
+		expected := "special.dockerfile.dockerignore"
+		input := "special.dockerfile"
+		actual := mapDockerignore(input)
+		assert.Equal(t, expected, actual)
+	})
+
+}

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -502,7 +502,7 @@ func TestMapDockerignore(t *testing.T) {
 
 	t.Run("Returns default .dockerignore", func(t *testing.T) {
 		expected := ".dockerignore"
-		input := "Dockerfile"
+		input := defaultDockerfile
 		actual := mapDockerignore(input)
 		assert.Equal(t, expected, actual)
 	})

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -523,7 +523,7 @@ func (accumulator *contextHashAccumulator) hexSumContext() string {
 
 func hashContext(dockerContextPath string, dockerfile string) (string, error) {
 	// exclude all files listed in dockerignore
-	dockerIgnorePath := filepath.Join(dockerContextPath, ".dockerignore")
+	dockerIgnorePath := filepath.Join(dockerContextPath, mapDockerignore(filepath.Base(dockerfile)))
 	ignorePatterns, err := getIgnore(dockerIgnorePath)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Docker can map .dockerignore files to dockerfiles 
via the following behavior:

1. `Dockerfile` maps to `.dockerignore`
2. `CustomNameDockerfile` maps to `CustomNameDockerfile.dockerignore`.

This PR adds that mapping, uses it in appropriate locations, and verifies behavior with unit and integration tests.

Fixes #568 

- Add function to map additional dockerignore files.
- Add integration tests for .dockerignore
