### PR TITLE
Refactor context hash to avoid computing relative Dockerfile path

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -234,7 +234,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 	// make the build options
 	opts := types.ImageBuildOptions{
 		Dockerfile: replaceDockerfile,
-		Tags:       []string{img.Name}, //this should build the image locally, sans registry info
+		Tags:       []string{img.Name}, // this should build the image locally, sans registry info
 		CacheFrom:  img.Build.CachedImages,
 		BuildArgs:  build.Args,
 		Version:    build.BuilderVersion,

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -463,7 +463,10 @@ type contextHashAccumulator struct {
 // points to is hashed. If it is a regular file, we hash the contents of the file. In order to
 // detect file renames and mode changes, we also write to the accumulator a relative name and file
 // mode.
-func (accumulator *contextHashAccumulator) hashPath(filePath string, relativeNameOfFile string, fileMode fs.FileMode) error {
+func (accumulator *contextHashAccumulator) hashPath(
+	filePath string,
+	relativeNameOfFile string,
+	fileMode fs.FileMode) error {
 	hash := sha256.New()
 
 	if fileMode.Type() == fs.ModeSymlink {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -152,14 +152,7 @@ func (p *dockerNativeProvider) Check(ctx context.Context, req *rpc.CheckRequest)
 			"Try setting `dockerfile` to %q", build.Dockerfile, relPath)
 
 	}
-	// Get the relative path to Dockerfile from docker context
-	relDockerfile, err := getRelDockerfilePath(build.Context, build.Dockerfile)
-	if err != nil {
-		return nil, err
-	}
-
-	// Hash docker build context digest
-	contextDigest, err := hashContext(build.Context, relDockerfile)
+	contextDigest, err := hashContext(build.Context, build.Dockerfile)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +459,11 @@ type contextHashAccumulator struct {
 	input             bytes.Buffer // This will hold the file info and content bytes to pass to a hash object
 }
 
-func (accumulator *contextHashAccumulator) hashPath(file string, fileMode fs.FileMode) error {
+// hashPath accumulates hashes for files in a directory. If the file is a symlink, the location it
+// points to is hashed. If it is a regular file, we hash the contents of the file. In order to
+// detect file renames and mode changes, we also write to the accumulator a relative name and file
+// mode.
+func (accumulator *contextHashAccumulator) hashPath(filePath string, relativeNameOfFile string, fileMode fs.FileMode) error {
 	hash := sha256.New()
 
 	if fileMode.Type() == fs.ModeSymlink {
@@ -475,31 +472,31 @@ func (accumulator *contextHashAccumulator) hashPath(file string, fileMode fs.Fil
 		// a) ignore changes at the symlink target
 		// b) detect if the symlink _itself_ changes
 		// c) avoid a panic on io.Copy if the symlink target is a directory
-		symLinkPath, err := filepath.EvalSymlinks(filepath.Join(accumulator.dockerContextPath, file))
+		symLinkPath, err := filepath.EvalSymlinks(filePath)
 		if err != nil {
-			return fmt.Errorf("could not evaluate symlink at %s: %w", file, err)
+			return fmt.Errorf("could not evaluate symlink at %s: %w", filePath, err)
 		}
 		// Hashed content is the clean, os-agnostic file path:
-		_, err = io.Copy(hash, strings.NewReader(path.Clean(symLinkPath)))
+		_, err = io.Copy(hash, strings.NewReader(filepath.ToSlash(filepath.Clean(symLinkPath))))
 		if err != nil {
-			return fmt.Errorf("could not copy symlink path %s to hash: %w", file, err)
+			return fmt.Errorf("could not copy symlink path %s to hash: %w", filePath, err)
 		}
 	} else {
 		// For regular files, we can hash their content.
 		// TODO: consider only hashing file metadata to improve performance
-		f, err := os.Open(filepath.Join(accumulator.dockerContextPath, file))
+		f, err := os.Open(filePath)
 		if err != nil {
-			return fmt.Errorf("could not open file %s: %w", file, err)
+			return fmt.Errorf("could not open file %s: %w", filePath, err)
 		}
 		defer f.Close()
 		_, err = io.Copy(hash, f)
 		if err != nil {
-			return fmt.Errorf("could not copy file %s to hash: %w", file, err)
+			return fmt.Errorf("could not copy file %s to hash: %w", filePath, err)
 		}
 	}
 
-	// Capture all information in the accumulator buffer and add a separator
-	accumulator.input.Write([]byte(filepath.Clean(file))) // use os-agnostic filepath
+	// We use "filepath.ToSlash" to return an OS-agnostic path, which uses "/".
+	accumulator.input.Write([]byte(filepath.ToSlash(path.Clean(relativeNameOfFile))))
 	accumulator.input.Write([]byte(fileMode.String()))
 	accumulator.input.Write(hash.Sum(nil))
 	accumulator.input.WriteByte(0)
@@ -528,7 +525,16 @@ func hashContext(dockerContextPath string, dockerfile string) (string, error) {
 	}
 
 	accumulator := contextHashAccumulator{dockerContextPath: dockerContextPath}
-	err = accumulator.hashPath(dockerfile, 0)
+	// The dockerfile is always hashed into the digest with the same "name", regardless of its actual
+	// name.
+	//
+	// If the dockerfile is outside the build context, this matches Docker's behavior. Whether it's
+	// "foo.Dockerfile" or "bar.Dockerfile", the builder only cares about its contents, not its name.
+	//
+	// If the dockerfile is inside the build context, we will hash it twice, but that is OK. We hash
+	// it here the first time with the name "Dockerfile", and then in the WalkDir loop on we hash it
+	// again with its actual name.
+	err = accumulator.hashPath(dockerfile, defaultDockerfile, 0)
 	if err != nil {
 		return "", fmt.Errorf("error hashing dockerfile %q: %w", dockerfile, err)
 	}
@@ -537,15 +543,16 @@ func hashContext(dockerContextPath string, dockerfile string) (string, error) {
 		if err != nil {
 			return err
 		}
-		path, err = filepath.Rel(dockerContextPath, path)
-
+		// The relative path is used in checking against .dockerignore and what is used in computing the
+		// name of the file hashed.
+		relPath, err := filepath.Rel(dockerContextPath, path)
 		if err != nil {
 			return err
 		}
-		if path == "." {
+		if relPath == "." {
 			return nil
 		}
-		ignore, err := ignoreMatcher.MatchesOrParentMatches(path)
+		ignore, err := ignoreMatcher.MatchesOrParentMatches(relPath)
 		if err != nil {
 			return fmt.Errorf("%s rule failed: %w", dockerIgnorePath, err)
 		}
@@ -557,13 +564,14 @@ func hashContext(dockerContextPath string, dockerfile string) (string, error) {
 		}
 		fileInfo, err := d.Info()
 		if err != nil {
-			return fmt.Errorf("determining mode for %q: %w", path, err)
+			return fmt.Errorf("determining mode for %q: %w", relPath, err)
 		}
 
-		err = accumulator.hashPath(path, fileInfo.Mode())
+		// We pass in the full path to the file, not the relative path above
+		err = accumulator.hashPath(path, relPath, fileInfo.Mode())
 
 		if err != nil {
-			return fmt.Errorf("error while hashing %q: %w", path, err)
+			return fmt.Errorf("error while hashing %q: %w", relPath, err)
 		}
 		return nil
 	})
@@ -589,25 +597,4 @@ func getIgnore(dockerIgnorePath string) ([]string, error) {
 		return ignorePatterns, fmt.Errorf("unable to parse %s file: %w", ".dockerignore", err)
 	}
 	return ignorePatterns, nil
-}
-
-func getRelDockerfilePath(buildContext, dockerfile string) (string, error) {
-	// if the Pulumi program specifies an absolute path or a path relative to the program's local directory,
-	// we need to get the Dockerfile's relative path to the context directory for the hash function
-	if strings.Contains(dockerfile, string(filepath.Separator)) {
-		absDockerfile, err := filepath.Abs(dockerfile)
-		if err != nil {
-			return "", fmt.Errorf("absDockerfile error: %s", err)
-		}
-		absBuildpath, err := filepath.Abs(buildContext)
-		if err != nil {
-			return "", fmt.Errorf("absBuildPath error: %s", err)
-		}
-		dockerfile, err = filepath.Rel(absBuildpath, absDockerfile)
-		if err != nil {
-			return "", fmt.Errorf("relDockerfile error: %s", err)
-		}
-
-	}
-	return dockerfile, nil
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -165,7 +165,7 @@ func TestHashDeepSymlinks(t *testing.T) {
 
 func TestHashUnignoredDirs(t *testing.T) {
 	step1Dir := "./testdata/unignores/basedir"
-	baseResult, err := hashContext(step1Dir, filepath.Join(step1Dir, defaultDockerfile)
+	baseResult, err := hashContext(step1Dir, filepath.Join(step1Dir, defaultDockerfile))
 	require.NoError(t, err)
 
 	step2Dir := "./testdata/unignores/basedir-with-unignored-dirs"

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -168,7 +168,7 @@ func TestHashUnignoredDirs(t *testing.T) {
 	baseResult, err := hashContext(step1Dir, filepath.Join(step1Dir, defaultDockerfile))
 	require.NoError(t, err)
 
-	step2Dir := "./testdata/unignores/basedir-with-unignored-dirs"
+	step2Dir := "./testdata/unignores/basedir-with-unignored-files"
 	unignoreResult, err := hashContext(step2Dir, filepath.Join(step2Dir, defaultDockerfile))
 	require.NoError(t, err)
 

--- a/provider/testdata/dockerfile-location-irrelevant/app/foo.sh
+++ b/provider/testdata/dockerfile-location-irrelevant/app/foo.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Hello, World!"

--- a/provider/testdata/dockerfile-location-irrelevant/step1.Dockerfile
+++ b/provider/testdata/dockerfile-location-irrelevant/step1.Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+WORKDIR /app
+
+COPY ./bar .

--- a/provider/testdata/dockerfile-location-irrelevant/step2.Dockerfile
+++ b/provider/testdata/dockerfile-location-irrelevant/step2.Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+WORKDIR /app
+
+COPY ./bar .


### PR DESCRIPTION
This fixes #578 by refactoring context hashing to not rely on a relative Dockerfile path. This check was a little error-prone, because it didn't account for forward slashes on Windows as a valid path separator.

```go
  if strings.Contains(dockerfile, string(filepath.Separator)) {
```

However, we don't need to compute the relative path for the Dockerfile if we change `hashContext` to allow the Dockerfile to be specified with an absolute or relative path to the project directory.

The most obvious test to include here is that if the Dockerfile is outside of the build context, the context hash is now agnostic to the name of the Dockerfile. This matches Docker's behavior, and a unit test was added accordingly.