### PR TITLE
Fix accept secrets=false to configure provider with nested secrets

### DIFF
--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -124,6 +124,15 @@ func TestDockerContainerRegistryDotnet(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestSecretsInExplicitProvider(t *testing.T) {
+	test := getCsharpBaseOptions(t).With(integration.ProgramTestOptions{
+		Dir:         path.Join(getCwd(t), "test-secrets-in-explicit-provider", "csharp"),
+		Quick:       true,
+		SkipRefresh: true,
+	})
+	integration.ProgramTest(t, &test)
+}
+
 func getCsharpBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions()
 	baseCsharp := base.With(integration.ProgramTestOptions{

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -1,3 +1,4 @@
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,11 +17,14 @@
 package examples
 
 import (
-	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
-	"github.com/stretchr/testify/assert"
+	"encoding/json"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
 func TestUnknownInputsYAML(t *testing.T) {
@@ -54,8 +58,13 @@ func TestSecretsYAML(t *testing.T) {
 			imgName, ok := stack.Outputs["imageName"]
 			assert.True(t, ok)
 			assert.NotEmpty(t, imgName)
-			assert.Equal(t, "pulumibot/test-secrets:yaml", imgName)
 
+			// imgName is going to be a secret value encoded as a map. Currently ProgramTest lacks the
+			// capacity to decrypt it and check the contents. For now we simply ensure that the secret
+			// information is not present plaintext in the JSON expansion of this value.
+			imgNameStr, err := json.Marshal(imgName)
+			assert.NoError(t, err)
+			assert.NotContains(t, imgNameStr, "pulumibot/test-secrets:yaml")
 		},
 	})
 }

--- a/examples/test-secrets-in-explicit-provider/csharp/Program.cs
+++ b/examples/test-secrets-in-explicit-provider/csharp/Program.cs
@@ -1,0 +1,24 @@
+﻿using Pulumi;
+using System.Collections.Generic;
+
+return await Deployment.RunAsync(() =>
+{
+   var provider = new Pulumi.Docker.Provider("docker", new Pulumi.Docker.ProviderArgs
+   {
+      Host = "host",
+      RegistryAuth = new List<Pulumi.Docker.Inputs.ProviderRegistryAuthArgs>
+      {
+         new Pulumi.Docker.Inputs.ProviderRegistryAuthArgs
+         {
+            Address = "somewhere.org",
+            Username = "some-user",
+            Password = "some-password"
+         }
+      }
+   });
+
+   return new Dictionary<string, object?>
+   {
+      ["outputKey"] = "outputValue"
+   };
+});

--- a/examples/test-secrets-in-explicit-provider/csharp/Pulumi.yaml
+++ b/examples/test-secrets-in-explicit-provider/csharp/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: docker-640
+runtime: dotnet
+description: A minimal C# Pulumi program reproducing pulumi/pulumi-docker/issues/640

--- a/examples/test-secrets-in-explicit-provider/csharp/docker-640.csproj
+++ b/examples/test-secrets-in-explicit-provider/csharp/docker-640.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
+    <PackageReference Include="Pulumi.Docker" Version="4.*" />
+  </ItemGroup>
+
+</Project>

--- a/provider/hybrid.go
+++ b/provider/hybrid.go
@@ -78,10 +78,10 @@ func (dp dockerHybridProvider) Configure(
 		return nil, fmt.Errorf("Docker native provider returned an unexpected error from Configure: %w", err)
 	}
 
-	contract.Assertf(r.AcceptOutputs, "Unexpected AcceptOutputs=true from Docker native provider Configure")
-	contract.Assertf(r.AcceptResources, "Unexpected AcceptResources=true from Docker native provider Configure")
-	contract.Assertf(r.AcceptSecrets, "Unexpected AcceptSecrets=true from Docker native provider Configure")
-	contract.Assertf(r.SupportsPreview, "Unexpected SupportsPreview=true from Docker native provider Configure")
+	contract.Assertf(!r.AcceptOutputs, "Unexpected AcceptOutputs=true from Docker native provider Configure")
+	contract.Assertf(!r.AcceptResources, "Unexpected AcceptResources=true from Docker native provider Configure")
+	contract.Assertf(!r.AcceptSecrets, "Unexpected AcceptSecrets=true from Docker native provider Configure")
+	contract.Assertf(!r.SupportsPreview, "Unexpected SupportsPreview=true from Docker native provider Configure")
 
 	// Mostly delegate Configure handling to the bridged provider.
 	return dp.bridgedProvider.Configure(ctx, request)

--- a/provider/hybrid.go
+++ b/provider/hybrid.go
@@ -77,7 +77,11 @@ func (dp dockerHybridProvider) Configure(
 	if err != nil {
 		return nil, fmt.Errorf("Docker native provider returned an unexpected error from Configure: %w", err)
 	}
-	if reflect.DeepEqual(resp, &rpc.ConfigureResponse{}) {
+
+	if resp.AcceptOutputs != false ||
+		resp.AcceptResources != false ||
+		resp.AcceptSecrets != false ||
+		resp.SupportsPreview != false {
 		return nil, fmt.Errorf("Docker native provider returned an unexpected non-empty "+
 			"response from Configure: %v", resp)
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -77,9 +77,7 @@ func (p *dockerNativeProvider) Configure(_ context.Context, req *rpc.ConfigureRe
 	for key, val := range req.GetVariables() {
 		p.config[strings.TrimPrefix(key, "docker:config:")] = val
 	}
-	return &rpc.ConfigureResponse{
-		AcceptSecrets: true,
-	}, nil
+	return &rpc.ConfigureResponse{}, nil
 }
 
 // Invoke dynamically executes a built-in function in the provider.

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc/codes"
@@ -286,6 +287,10 @@ func diffUpdates(updates map[resource.PropertyKey]resource.ValueDiff) map[string
 
 // Create allocates a new instance of the provided resource and returns its unique ID afterwards.
 func (p *dockerNativeProvider) Create(ctx context.Context, req *rpc.CreateRequest) (*rpc.CreateResponse, error) {
+	contract.Assertf(!req.GetPreview(), "Internal error in pulumi-docker: "+
+		"dockerNativeProvider Create should not be called during preview "+
+		"as it currently does not support partial data or recognizing unknowns.")
+
 	urn := resource.URN(req.GetUrn())
 	label := fmt.Sprintf("%s.Create(%s)", p.name, urn)
 	logging.V(9).Infof("%s executing", label)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -287,7 +287,7 @@ func diffUpdates(updates map[resource.PropertyKey]resource.ValueDiff) map[string
 
 // Create allocates a new instance of the provided resource and returns its unique ID afterwards.
 func (p *dockerNativeProvider) Create(ctx context.Context, req *rpc.CreateRequest) (*rpc.CreateResponse, error) {
-	contract.Assertf(!req.GetPreview(), "Internal error in pulumi-docker: "+
+	contract.Assertf(req.GetPreview(), "Internal error in pulumi-docker: "+
 		"dockerNativeProvider Create should not be called during preview "+
 		"as it currently does not support partial data or recognizing unknowns.")
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -287,7 +287,7 @@ func diffUpdates(updates map[resource.PropertyKey]resource.ValueDiff) map[string
 
 // Create allocates a new instance of the provided resource and returns its unique ID afterwards.
 func (p *dockerNativeProvider) Create(ctx context.Context, req *rpc.CreateRequest) (*rpc.CreateResponse, error) {
-	contract.Assertf(req.GetPreview(), "Internal error in pulumi-docker: "+
+	contract.Assertf(!req.GetPreview(), "Internal error in pulumi-docker: "+
 		"dockerNativeProvider Create should not be called during preview "+
 		"as it currently does not support partial data or recognizing unknowns.")
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-docker/issues/640

Our current design for handling program-originating secrets in bridged providers is to basically let the engine (Pulumi CLI) handle it for us. Bridged providers return "acceptsSecrets=false" to the engine, which then does not pass secret bits to Configure or Create but instead passes plain data and does some heuristic matching on the resource/provider outputs to make sure secret data stays secret.

Unfortunately due to how Configure was written in dockerHybridProvider struct here which multiplexes traffic between bridged and native providers, this information got lost and the docker provider returned acceptsSecrets=true to the engine, while not protecting the bridged provider from unexpected secrets. This caused a panic deep in the bridged provider when a secret was passed.

The fix is to ensure  the hybrid provider returns the same options as the bridgedProvider, with a notable exception of supportsPreview - which currently is supported in the bridged but not the native provider, and has to be disabled when mixing them into the hybrid provider.