### PR TITLE
Add a Node test for secrets handling

### DIFF
--- a/examples/test-secrets-in-explicit-provider/csharp/Program.cs
+++ b/examples/test-secrets-in-explicit-provider/csharp/Program.cs
@@ -8,7 +8,7 @@ using Pulumi.Random;
 return await Deployment.RunAsync(() =>
 {
    // Test handling secrets marked by the program.
-   var providerWithSecretAddress = new Pulumi.Docker.Provider("provider-with-secret-address", new Pulumi.Docker.ProviderArgs
+   var providerWithSecretAddress = new Pulumi.Docker.Provider("provider-with-sensitive-address", new Pulumi.Docker.ProviderArgs
    {
       RegistryAuth = new List<Pulumi.Docker.Inputs.ProviderRegistryAuthArgs>
       {
@@ -27,7 +27,7 @@ return await Deployment.RunAsync(() =>
    });
 
    // Test handling dynamic secrets that start as unknown.
-   var providerWithSecretUsername = new Pulumi.Docker.Provider("provider-with-secret-username", new Pulumi.Docker.ProviderArgs
+   var providerWithSecretUsername = new Pulumi.Docker.Provider("provider-with-sensitive-username", new Pulumi.Docker.ProviderArgs
    {
       RegistryAuth = new List<Pulumi.Docker.Inputs.ProviderRegistryAuthArgs>
       {

--- a/examples/test-secrets-in-explicit-provider/ts/Dockerfile
+++ b/examples/test-secrets-in-explicit-provider/ts/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu AS base
+RUN echo "base"
+
+FROM base AS stage1
+RUN echo "stage1"
+
+FROM base AS stage2
+RUN echo "stage2"

--- a/examples/test-secrets-in-explicit-provider/ts/Dockerfile
+++ b/examples/test-secrets-in-explicit-provider/ts/Dockerfile
@@ -1,8 +1,0 @@
-FROM ubuntu AS base
-RUN echo "base"
-
-FROM base AS stage1
-RUN echo "stage1"
-
-FROM base AS stage2
-RUN echo "stage2"

--- a/examples/test-secrets-in-explicit-provider/ts/Pulumi.yaml
+++ b/examples/test-secrets-in-explicit-provider/ts/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: test-unknowns
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/examples/test-secrets-in-explicit-provider/ts/index.ts
+++ b/examples/test-secrets-in-explicit-provider/ts/index.ts
@@ -1,0 +1,33 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as docker from "@pulumi/docker";
+import * as random from "@pulumi/random";
+
+const providerWithSecretAddress = new docker.Provider("provider-with-sensitive-address", {
+    registryAuth: [{
+        address: pulumi.secret("secret-address"),
+        username: "some-user",
+    }],
+})
+
+const passwordResource = new random.RandomPassword("random", {
+    length: 16,
+    special: false,
+});
+
+const providerWithSecretUsername = new docker.Provider("provider-with-sensitive-username", {
+    registryAuth: [{
+        address: "some-address",
+        username: passwordResource.result,
+    }],
+})
+
+const providerWithSecretPassword = new docker.Provider("provider-with-password", {
+    registryAuth: [{
+        address: "some-address",
+        username: "some-user",
+        password: "secret-password",
+    }],
+})
+
+export const password = pulumi.unsecret(passwordResource.result)
+    .apply(x => Buffer.from(x).toString('base64'));

--- a/examples/test-secrets-in-explicit-provider/ts/package.json
+++ b/examples/test-secrets-in-explicit-provider/ts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-unknowns",
+  "devDependencies": {
+    "@types/node": "^14.0.0"
+  },
+  "dependencies": {
+    "@pulumi/docker": "^4.1.0",
+    "@pulumi/random": "^4.12.1",
+    "@pulumi/pulumi": "^3.0.0"
+  }
+}

--- a/examples/test-secrets-in-explicit-provider/ts/tsconfig.json
+++ b/examples/test-secrets-in-explicit-provider/ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2016",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}


### PR DESCRIPTION
This test collects more evidence on https://github.com/pulumi/pulumi-dotnet/issues/142 

All the asserts pass in TypeScript, so this is good support for the hypothesis that the issue is peculiar to .NET SDK generation and does not affect other languages.

