### PR TITLE
Fix Windows filepath for Dockerfile

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -140,10 +140,14 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		return "", nil, fmt.Errorf("relDockerfile error: %s", err)
 	}
 
-	// if the dockerfile is in the context it will be something like "./Dockerfile" or ".\sub\dir\Dockerfile"
+	// filepath.Abs returns the filepath with the os' filepath separator.
+	// To clean this up, we convert the filepath to a forward slash.
+	relDockerfile = filepath.ToSlash(relDockerfile)
+
+	// if the dockerfile is in the context it will be something like "./Dockerfile" or "./sub/dir/Dockerfile"
 	// if the dockerfile is out of the context it will begin with "../"
 	dockerfileInContext := true
-	if strings.HasPrefix(relDockerfile, ".."+string(filepath.Separator)) {
+	if strings.HasPrefix(relDockerfile, "../") {
 		dockerfileInContext = false
 	}
 


### PR DESCRIPTION
It turns out that `filepath.Abs` returns the filepath with the os separator for the os we're running on.
We then call `filepath.Rel` on the Dockerfile and the docker context. 
If a Dockerfile is more than one folder away from its context, it means its relative path now contains the filepath separators for the host os. 
When that gets re-added to the build tarball by Docker, the client cannot open the Dockerfile on Windows because it contains backslashes in the final bit of its filepath:
`/var/lib/docker/tmp/buildkit-mount1961648446/EchoApp\Dockerfile`
With this PR, we ensure the relative path for the Dockerfile contains only forward (unix-style) slashes.
We verified that this runs correctly on Windows now.

Fixes #624.
