### PR TITLE
Use fsutil.Walk() to compute context digest

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -542,16 +542,18 @@ func hashContext(dockerContextPath string, dockerfile string) (string, error) {
 	}
 	err = fsutil.Walk(context.Background(), dockerContextPath, &fsutil.WalkOpt{
 		ExcludePatterns: ignorePatterns,
-	}, func(relPath string, d fs.FileInfo, err error) error {
+	}, func(filePath string, fileInfo fs.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
+		if fileInfo.IsDir() {
 			return nil
 		}
-		err = accumulator.hashPath(filepath.Join(dockerContextPath, relPath), relPath, d.Mode())
+		// fsutil.Walk makes filePath relative to the root, we join it back to get an absolute path to
+		// the file to hash.
+		err = accumulator.hashPath(filepath.Join(dockerContextPath, filePath), filePath, fileInfo.Mode())
 		if err != nil {
-			return fmt.Errorf("error while hashing %q: %w", relPath, err)
+			return fmt.Errorf("error while hashing %q: %w", filePath, err)
 		}
 		return nil
 	})

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -11,7 +12,6 @@ import (
 )
 
 func TestDiffUpdates(t *testing.T) {
-
 	t.Run("No diff happens on changed password", func(t *testing.T) {
 		expected := map[string]*rpc.PropertyDiff{}
 		input := map[resource.PropertyKey]resource.ValueDiff{
@@ -119,6 +119,56 @@ func TestHashIgnoresFile(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, result, baseResult)
+}
+
+// Tests that we handle .dockerignore exclusions such as "!foo/*/bar".
+//
+// See:
+// - https://github.com/moby/moby/issues/30018
+// - https://github.com/moby/moby/issues/45608
+//
+// Buildkit handles these correctly (according to spec), Docker's classic builder does not.
+func TestHashIgnoresWildcards(t *testing.T) {
+	baselineDir := "testdata/ignores-wildcard/basedir"
+	baselineResult, err := hashContext(baselineDir, filepath.Join(baselineDir, defaultDockerfile))
+	require.NoError(t, err)
+
+	modIgnoredDir := "testdata/ignores-wildcard/basedir-modified-ignored-file"
+	modIgnoredResult, err := hashContext(modIgnoredDir, filepath.Join(modIgnoredDir, defaultDockerfile))
+	require.NoError(t, err)
+
+	modIncludedDir := "testdata/ignores-wildcard/basedir-modified-included-file"
+	modIncludedResult, err := hashContext(modIncludedDir, filepath.Join(modIncludedDir, defaultDockerfile))
+	require.NoError(t, err)
+
+	assert.Equal(t, baselineResult, modIgnoredResult, "hash should not change when modifying ignored files")
+	assert.NotEqual(t, baselineResult, modIncludedResult, "hash should change when modifying included (via wildcard ignore exclusion) files")
+}
+
+// Tests that we handle .dockerignore exclusions such as "!foo/*/bar", as above, when using a
+// relative context path.
+func TestHashIgnoresWildcardsRelative(t *testing.T) {
+	err := os.Chdir("pkg")
+	require.NoError(t, err)
+	defer func() {
+		err = os.Chdir("..")
+		require.NoError(t, err)
+	}()
+
+	baselineDir := "../testdata/ignores-wildcard/basedir"
+	baselineResult, err := hashContext(baselineDir, filepath.Join(baselineDir, defaultDockerfile))
+	require.NoError(t, err)
+
+	modIgnoredDir := "../testdata/ignores-wildcard/basedir-modified-ignored-file"
+	modIgnoredResult, err := hashContext(modIgnoredDir, filepath.Join(modIgnoredDir, defaultDockerfile))
+	require.NoError(t, err)
+
+	modIncludedDir := "../testdata/ignores-wildcard/basedir-modified-included-file"
+	modIncludedResult, err := hashContext(modIncludedDir, filepath.Join(modIncludedDir, defaultDockerfile))
+	require.NoError(t, err)
+
+	assert.Equal(t, baselineResult, modIgnoredResult, "hash should not change when modifying ignored files")
+	assert.NotEqual(t, baselineResult, modIncludedResult, "hash should change when modifying included (via wildcard ignore exclusion) files")
 }
 
 func TestHashIgnoresDockerfileOutsideDirMove(t *testing.T) {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -142,7 +142,8 @@ func TestHashIgnoresWildcards(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, baselineResult, modIgnoredResult, "hash should not change when modifying ignored files")
-	assert.NotEqual(t, baselineResult, modIncludedResult, "hash should change when modifying included (via wildcard ignore exclusion) files")
+	assert.NotEqual(t, baselineResult, modIncludedResult,
+		"hash should change when modifying included (via wildcard ignore exclusion) files")
 }
 
 // Tests that we handle .dockerignore exclusions such as "!foo/*/bar", as above, when using a
@@ -168,7 +169,8 @@ func TestHashIgnoresWildcardsRelative(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, baselineResult, modIgnoredResult, "hash should not change when modifying ignored files")
-	assert.NotEqual(t, baselineResult, modIncludedResult, "hash should change when modifying included (via wildcard ignore exclusion) files")
+	assert.NotEqual(t, baselineResult, modIncludedResult,
+		"hash should change when modifying included (via wildcard ignore exclusion) files")
 }
 
 func TestHashIgnoresDockerfileOutsideDirMove(t *testing.T) {

--- a/provider/testdata/ignores-wildcard/basedir-modified-ignored-file/.dockerignore
+++ b/provider/testdata/ignores-wildcard/basedir-modified-ignored-file/.dockerignore
@@ -1,0 +1,7 @@
+# Ignore everything!
+*
+
+# Except changes to source data in this set of directories:
+!projects/*/src
+
+# This should therefore IGNORE projects/*/dist

--- a/provider/testdata/ignores-wildcard/basedir-modified-ignored-file/Dockerfile
+++ b/provider/testdata/ignores-wildcard/basedir-modified-ignored-file/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+WORKDIR /app
+
+COPY ./bar .

--- a/provider/testdata/ignores-wildcard/basedir-modified-ignored-file/projects/foo/src/app.js
+++ b/provider/testdata/ignores-wildcard/basedir-modified-ignored-file/projects/foo/src/app.js
@@ -1,0 +1,1 @@
+console.log("Pulumi 💜");

--- a/provider/testdata/ignores-wildcard/basedir-modified-included-file/.dockerignore
+++ b/provider/testdata/ignores-wildcard/basedir-modified-included-file/.dockerignore
@@ -1,0 +1,7 @@
+# Ignore everything!
+*
+
+# Except changes to source data in this set of directories:
+!projects/*/src
+
+# This should therefore IGNORE projects/*/dist

--- a/provider/testdata/ignores-wildcard/basedir-modified-included-file/Dockerfile
+++ b/provider/testdata/ignores-wildcard/basedir-modified-included-file/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+WORKDIR /app
+
+COPY ./bar .

--- a/provider/testdata/ignores-wildcard/basedir-modified-included-file/projects/foo/src/app.js
+++ b/provider/testdata/ignores-wildcard/basedir-modified-included-file/projects/foo/src/app.js
@@ -1,0 +1,1 @@
+console.log("💜 Pulumi (included)");

--- a/provider/testdata/ignores-wildcard/basedir/.dockerignore
+++ b/provider/testdata/ignores-wildcard/basedir/.dockerignore
@@ -1,0 +1,7 @@
+# Ignore everything!
+*
+
+# Except changes to source data in this set of directories:
+!projects/*/src
+
+# This should therefore IGNORE projects/*/dist

--- a/provider/testdata/ignores-wildcard/basedir/Dockerfile
+++ b/provider/testdata/ignores-wildcard/basedir/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+WORKDIR /app
+
+COPY ./bar .

--- a/provider/testdata/ignores-wildcard/basedir/projects/foo/src/app.js
+++ b/provider/testdata/ignores-wildcard/basedir/projects/foo/src/app.js
@@ -1,0 +1,1 @@
+console.log("Pulumi 💜");


### PR DESCRIPTION
This removes the `patternmatcher` library and replaces our context walk with the same library as used in Buildkit.

It turns out we *may* have already fixed #607 in #596, as the tests pass without changes to `provider.go`. However, there is logic in `fsutil.Walk()` absent in our previous implementation and it makes sense to limit the scope of the provider to reusing the routine from the `fsutil` library.

Fixes #607