### PR TITLE
Native Provider Config: Handle environment variables correctly

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -742,7 +742,6 @@ func processLogLine(msg string) (string, error) {
 }
 
 func configureDockerClient(configs map[string]string) (*client.Client, error) {
-	fmt.Println("🦉🦉🦉🦉🦉🦉 CONFIG", configs)
 	// check for TLS inputs
 	var caMaterial, certMaterial, keyMaterial, certPath, host string
 	if val, ok := configs["caMaterial"]; ok {

--- a/provider/image.go
+++ b/provider/image.go
@@ -742,6 +742,7 @@ func processLogLine(msg string) (string, error) {
 }
 
 func configureDockerClient(configs map[string]string) (*client.Client, error) {
+	fmt.Println("🦉🦉🦉🦉🦉🦉 CONFIG", configs)
 	// check for TLS inputs
 	var caMaterial, certMaterial, keyMaterial, certPath, host string
 	if val, ok := configs["caMaterial"]; ok {

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -428,12 +428,6 @@ func TestConfigureDockerClient(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual.DaemonHost())
 	})
-	t.Run("Given a host passed via environment, a client should be configured", func(t *testing.T) {
-		input := map[string]string{}
-		actual, err := configureDockerClient(input)
-		assert.NoError(t, err)
-		assert.NotNil(t, actual)
-	})
 
 	t.Run("For TLS, must pass certMaterial, keyMaterial, and caMaterial", func(t *testing.T) {
 		input := map[string]string{

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -75,8 +75,26 @@ func (p *dockerNativeProvider) DiffConfig(ctx context.Context, req *rpc.DiffRequ
 
 // Configure configures the resource provider with "globals" that control its behavior.
 func (p *dockerNativeProvider) Configure(_ context.Context, req *rpc.ConfigureRequest) (*rpc.ConfigureResponse, error) {
+
 	for key, val := range req.GetVariables() {
 		p.config[strings.TrimPrefix(key, "docker:config:")] = val
+	}
+	// get env vars, if any.
+	// Because historically we give precedence to env vars over config vars, we overwrite here.
+	if value := os.Getenv("DOCKER_HOST"); value != "" {
+		p.config["host"] = value
+	}
+	if value := os.Getenv("DOCKER_CA_MATERIAL"); value != "" {
+		p.config["caMaterial"] = value
+	}
+	if value := os.Getenv("DOCKER_CERT_MATERIAL"); value != "" {
+		p.config["certMaterial"] = value
+	}
+	if value := os.Getenv("DOCKER_KEY_MATERIAL"); value != "" {
+		p.config["keyMaterial"] = value
+	}
+	if value := os.Getenv("DOCKER_CERT_PATH"); value != "" {
+		p.config["certPath"] = value
 	}
 	return &rpc.ConfigureResponse{}, nil
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -226,3 +226,60 @@ func TestHashUnignoredDirs(t *testing.T) {
 
 	assert.Equal(t, baseResult, unignoreResult)
 }
+
+func TestSetConfiguration(t *testing.T) {
+	t.Run("Sets provider config correctly when passed a valid input map", func(t *testing.T) {
+		expected := map[string]string{
+			"host":       "thisisatesthost",
+			"caMaterial": "materialsareweird",
+		}
+		input := map[string]string{
+			"host":       "thisisatesthost",
+			"caMaterial": "materialsareweird",
+		}
+		actual := setConfiguration(input)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Sets provider config correctly from environment variables", func(t *testing.T) {
+		expected := map[string]string{
+			"host":       "thisisatesthost",
+			"caMaterial": "materialsareweird",
+		}
+		t.Setenv("DOCKER_HOST", "thisisatesthost")
+		t.Setenv("DOCKER_CA_MATERIAL", "materialsareweird")
+		input := map[string]string{}
+		actual := setConfiguration(input)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Sets provider config with preference to environment variables", func(t *testing.T) {
+		expected := map[string]string{
+			"host":       "thisisatesthost",
+			"caMaterial": "materialsareweird",
+		}
+		input := map[string]string{
+			"host":       "thishostshouldbeoverwritten",
+			"caMaterial": "materialsareweird",
+		}
+
+		t.Setenv("DOCKER_HOST", "thisisatesthost")
+
+		actual := setConfiguration(input)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Sets provider config by correctly merging stack config and env vars", func(t *testing.T) {
+		expected := map[string]string{
+			"host":        "thisisatesthost",
+			"caMaterial":  "materialsareweird",
+			"authConfigs": "authConfigs",
+		}
+		input := map[string]string{
+			"caMaterial":  "materialsareweird",
+			"authConfigs": "authConfigs",
+		}
+
+		t.Setenv("DOCKER_HOST", "thisisatesthost")
+
+		actual := setConfiguration(input)
+		assert.Equal(t, expected, actual)
+	})
+}


### PR DESCRIPTION
Fixes #671

- Read in environment variables when configuring the provider
- Factor out setting the configs and add unit tests
