### PR TITLE
Explicitly read in SSH config flags to the docker client configuration

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -390,11 +390,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.4.0
     - name: Setup SSH key
-      uses: shimataro/ssh-key-action@v2
+      uses: webfactory/ssh-agent@v0.7.0
       with:
-        key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
-        name: github-actions
-        known_hosts: unnecessary
+        ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -388,6 +388,12 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.4.0
+    - name: Setup SSH key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
+        name: github-actions
+        known_hosts: unnecessary
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -41,6 +41,7 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
+  DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
 jobs:
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/examples/digitalocean-container-registry/csharp/Program.cs
+++ b/examples/digitalocean-container-registry/csharp/Program.cs
@@ -57,8 +57,8 @@ class Program
             Registry = registryInfo,
         });
 
+        // Export the resulting image name.
         // Export the resulting base name in addition to the specific version pushed.
-	    // Export the resulting image name
         return new Dictionary<string, object?>
         {
             { "baseImageName", image.BaseImageName },

--- a/examples/digitalocean-container-registry/csharp/Program.cs
+++ b/examples/digitalocean-container-registry/csharp/Program.cs
@@ -10,7 +10,7 @@ using Pulumi.Docker.Inputs;
 
 class Program
 {
-    static Task<int> Main() => Deployment.RunAsync(async () => {
+    static Task<int> Main() => Deployment.RunAsync(() => {
         // Create a private DigitalOcean Container Registry.
         var registry = new ContainerRegistry("my-reg", new ContainerRegistryArgs
         {
@@ -33,7 +33,7 @@ class Program
                 var serverUrl = args[1];
                 dynamic auths = JsonConvert.DeserializeObject(authJson);
                 var authToken = auths["auths"][serverUrl]["auth"];
-                var decoded = ASCIIEncoding.ASCII.GetString(authToken);
+                var decoded = Encoding.ASCII.GetString(authToken);
 
                 var parts = decoded.Split(':');
                 if (parts.Length != 2)
@@ -41,7 +41,7 @@ class Program
                     throw new Exception("Invalid credentials");
                 }
 
-                return new Pulumi.Docker.Inputs.RegistryArgs
+                return new RegistryArgs
                 {
                     Server = serverUrl,
                     Username = parts[0],
@@ -52,15 +52,16 @@ class Program
         // Build and publish the app image.
         var image = new Image("my-image", new ImageArgs
         {
-            Build = new Pulumi.Docker.Inputs.DockerBuildArgs { Context = "app" },
+            Build = new DockerBuildArgs { Context = "app" },
             ImageName = imageName,
             Registry = registryInfo,
         });
 
         // Export the resulting base name in addition to the specific version pushed.
-	// Export the resulting image name
-        return new Dictionary<string, object>
+	    // Export the resulting image name
+        return new Dictionary<string, object?>
         {
+            { "baseImageName", image.BaseImageName },
             { "fullImageName", image.ImageName },
         };
     });

--- a/examples/digitalocean-container-registry/go/main.go
+++ b/examples/digitalocean-container-registry/go/main.go
@@ -16,8 +16,7 @@ func main() {
 		// Create a private DigitalOcean Container Registry.
 		registry, err := digitalocean.NewContainerRegistry(ctx, "my-reg",
 			&digitalocean.ContainerRegistryArgs{
-				// TODO: why is the following commented out?
-				// SubscriptionTierSlug: pulumi.String("starter"),
+				SubscriptionTierSlug: pulumi.String("starter"),
 			})
 		if err != nil {
 			return err

--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -82,7 +82,7 @@ func TestAwsContainerRegistryDotnet(t *testing.T) {
 }
 
 func TestDigitaloceanContainerRegistryDotnet(t *testing.T) {
-	t.Skipf("Skipping test due to known storageUsageBytes issue #718")
+	t.Skipf("Skipping test due to known storageUsageBytes issue https://github.com/pulumi/pulumi-docker/issues/718")
 
 	token := os.Getenv("DIGITALOCEAN_TOKEN")
 	if token == "" {

--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -82,6 +82,8 @@ func TestAwsContainerRegistryDotnet(t *testing.T) {
 }
 
 func TestDigitaloceanContainerRegistryDotnet(t *testing.T) {
+	t.Skipf("Skipping test due to known storageUsageBytes issue #718")
+
 	token := os.Getenv("DIGITALOCEAN_TOKEN")
 	if token == "" {
 		t.Skipf("Skipping test due to missing DIGITALOCEAN_TOKEN environment variable")

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -193,6 +193,8 @@ func TestAwsContainerRegistryGo(t *testing.T) {
 }
 
 func TestDigitaloceanContainerRegistryGo(t *testing.T) {
+	t.Skipf("Skipping test due to known storageUsageBytes issue #718")
+
 	token := os.Getenv("DIGITALOCEAN_TOKEN")
 	if token == "" {
 		t.Skipf("Skipping test due to missing DIGITALOCEAN_TOKEN environment variable")

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -193,7 +193,7 @@ func TestAwsContainerRegistryGo(t *testing.T) {
 }
 
 func TestDigitaloceanContainerRegistryGo(t *testing.T) {
-	t.Skipf("Skipping test due to known storageUsageBytes issue #718")
+	t.Skipf("Skipping test due to known storageUsageBytes issue https://github.com/pulumi/pulumi-docker/issues/718")
 
 	token := os.Getenv("DIGITALOCEAN_TOKEN")
 	if token == "" {

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -88,6 +88,8 @@ func TestAwsContainerRegistry(t *testing.T) {
 }
 
 func TestDigitaloceanContainerRegistry(t *testing.T) {
+	t.Skipf("Skipping test due to known storageUsageBytes issue #718")
+
 	token := os.Getenv("DIGITALOCEAN_TOKEN")
 	if token == "" {
 		t.Skipf("Skipping test due to missing DIGITALOCEAN_TOKEN environment variable")

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -87,7 +87,7 @@ func TestAwsContainerRegistry(t *testing.T) {
 }
 
 func TestDigitaloceanContainerRegistry(t *testing.T) {
-	t.Skipf("Skipping test due to known storageUsageBytes issue #718")
+	t.Skipf("Skipping test due to known storageUsageBytes issue https://github.com/pulumi/pulumi-docker/issues/718")
 
 	token := os.Getenv("DIGITALOCEAN_TOKEN")
 	if token == "" {

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/stretchr/testify/assert"
@@ -193,6 +194,32 @@ func TestSecretsInExplicitProviderNode(t *testing.T) {
 		SkipRefresh:            true,
 		ExtraRuntimeValidation: check,
 	})
+	integration.ProgramTest(t, &test)
+}
+
+func TestSSHConnNode(t *testing.T) {
+	token := os.Getenv("DIGITALOCEAN_TOKEN")
+	if token == "" {
+		t.Skipf("Skipping test due to missing DIGITALOCEAN_TOKEN environment variable")
+	}
+	test := getJsOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "test-ssh-conn", "ts"),
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				ipOutput, ok := stack.Outputs["ipOutput"]
+				assert.True(t, ok)
+				assert.NotEmpty(t, ipOutput)
+				// Due to a bug in the docker client, we add sleep here so our SSH connection does not get refused.
+				time.Sleep(20 * time.Second)
+			},
+			SkipRefresh:      true,
+			Quick:            true,
+			RetryFailedSteps: true,
+			Config: map[string]string{
+				"digitalocean:token": token,
+			},
+			Verbose: true,
+		})
 	integration.ProgramTest(t, &test)
 }
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/stretchr/testify/assert"
@@ -211,8 +210,6 @@ func TestSSHConnNode(t *testing.T) {
 				ipOutput, ok := stack.Outputs["ipOutput"]
 				assert.True(t, ok)
 				assert.NotEmpty(t, ipOutput)
-				// Due to a bug in the docker client, we add sleep here so our SSH connection does not get refused.
-				time.Sleep(20 * time.Second)
 			},
 			SkipRefresh:      true,
 			Quick:            true,

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -59,7 +59,7 @@ func TestAwsContainerRegistryPy(t *testing.T) {
 }
 
 func TestDigitaloceanContainerRegistryPy(t *testing.T) {
-	t.Skipf("Skipping test due to known storageUsageBytes issue #718")
+	t.Skipf("Skipping test due to known storageUsageBytes issue https://github.com/pulumi/pulumi-docker/issues/718")
 
 	token := os.Getenv("DIGITALOCEAN_TOKEN")
 	if token == "" {

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -59,6 +59,8 @@ func TestAwsContainerRegistryPy(t *testing.T) {
 }
 
 func TestDigitaloceanContainerRegistryPy(t *testing.T) {
+	t.Skipf("Skipping test due to known storageUsageBytes issue #718")
+
 	token := os.Getenv("DIGITALOCEAN_TOKEN")
 	if token == "" {
 		t.Skipf("Skipping test due to missing DIGITALOCEAN_TOKEN environment variable")

--- a/examples/test-ssh-conn/README.md
+++ b/examples/test-ssh-conn/README.md
@@ -1,0 +1,27 @@
+# SSH Connection Integration Test
+
+## Setup
+
+This test takes a bit of manual setup to work properly.
+
+In order to verify that a remote Docker host via SSH works correctly, we are setting up the following test stack:
+
+```bash
+ +   pulumi:pulumi:Stack
+ +   ├─ digitalocean:index:Droplet
+ +   ├─ pulumi:providers:docker
+ +   ├─ docker:index:RemoteImage
+ +   └─ docker:index:Container
+```
+
+We are imaging a Docker/Ubuntu Digitalocean Droplet as a remote docker host to pull a RemoteImage and run a Container. 
+We declare an explicit Docker provider so that we can configure it to use the IP output of the Droplet as our Docker host.
+
+1. Generate an ssh rsa key pair [according to GitHub's instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent), using your github email.
+1. Add the private key to the repository as `PRIVATE_SSH_KEY_FOR_DIGITALOCEAN`
+1. Upload the _public key_ to pulumi-bot's [digitalocean account](https://docs.digitalocean.com/products/droplets/how-to/add-ssh-keys/to-team/)
+1. Digitalocean will give you a fingerprint. Use this fingerprint to populate the `sshKeys` field of the DigitalOcean Droplet. This will ensure that the new Droplet will be created with the public key in its `authorized_keys` file.
+
+Caveats:
+
+- We connect as `root` because the Droplet does not come preconfigured with users.

--- a/examples/test-ssh-conn/ts/Pulumi.yaml
+++ b/examples/test-ssh-conn/ts/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: test-ssh-conn
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/examples/test-ssh-conn/ts/index.ts
+++ b/examples/test-ssh-conn/ts/index.ts
@@ -26,6 +26,7 @@ export const ipOutput = ip
 const provider = new docker.Provider("docker-provider", {
     host: pulumi.interpolate`ssh://root@${ip}`,
     sshOpts: [
+        "-i", "/home/runner/.ssh",
         "-o", "StrictHostKeyChecking=no",
         "-o", "UserKnownHostsFile=/dev/null"
     ],

--- a/examples/test-ssh-conn/ts/index.ts
+++ b/examples/test-ssh-conn/ts/index.ts
@@ -1,0 +1,44 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as docker from "@pulumi/docker";
+import * as digitalocean from "@pulumi/digitalocean";
+
+const remoteHost = new digitalocean.Droplet("docker-host-test", {
+    image: "docker-20-04",
+    region: "fra1",
+    size: "c-8",
+    sshKeys: ["cb:dd:70:4d:49:2f:86:eb:fd:bb:e4:8b:04:fc:b0:cb"],
+})
+
+function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+async function addSleep(addr: string, ms: number) {
+    console.log("Sleeping...")
+    await sleep(ms)
+    console.log("Done Sleeping")
+    return addr
+}
+
+let ip = remoteHost.ipv4Address.apply(ipv4Address => addSleep(ipv4Address, 20000))
+
+export const ipOutput = ip
+
+const provider = new docker.Provider("docker-provider", {
+    host: pulumi.interpolate`ssh://root@${ip}`,
+    sshOpts: [
+        "-o", "StrictHostKeyChecking=no",
+        "-o", "UserKnownHostsFile=/dev/null"
+    ],
+});
+
+const remoteImage = new docker.RemoteImage("image", {
+    name: "nginx"
+}, {
+    provider: provider
+});
+
+const container = new docker.Container("container", {
+    image: remoteImage.imageId
+}, {
+    provider: provider
+});

--- a/examples/test-ssh-conn/ts/index.ts
+++ b/examples/test-ssh-conn/ts/index.ts
@@ -19,7 +19,7 @@ async function addSleep(addr: string, ms: number) {
     return addr
 }
 
-let ip = remoteHost.ipv4Address.apply(ipv4Address => addSleep(ipv4Address, 20000))
+const ip = remoteHost.ipv4Address.apply(ipv4Address => addSleep(ipv4Address, 20000))
 
 export const ipOutput = ip
 
@@ -34,9 +34,7 @@ const provider = new docker.Provider("docker-provider", {
 
 const remoteImage = new docker.RemoteImage("image", {
     name: "nginx"
-}, {
-    provider: provider
-});
+}, { provider });
 
 const container = new docker.Container("container", {
     image: remoteImage.imageId

--- a/examples/test-ssh-conn/ts/package.json
+++ b/examples/test-ssh-conn/ts/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "test-ssh-conn",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^16"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/digitalocean": "latest"
+    }
+}

--- a/examples/test-ssh-conn/ts/tsconfig.json
+++ b/examples/test-ssh-conn/ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.ts"
+    ]
+}

--- a/provider/image.go
+++ b/provider/image.go
@@ -748,6 +748,7 @@ func processLogLine(msg string) (string, error) {
 // instead of the system-wide one.
 // `verify` is a testing affordance and will always be true in production.
 func configureDockerClient(configs map[string]string, verify bool) (*client.Client, error) {
+
 	host, isExplicitHost := configs["host"]
 
 	if !isExplicitHost {
@@ -849,8 +850,8 @@ func configureDockerClientInner(configs map[string]string, host string) (*client
 	} else {
 		// No TLS certificate material provided, create an http client
 		if host != "" {
+			sshopts := SSHOptsToSlice(configs["sshOpts"])
 			// first, check for ssh host
-			sshopts := []string{}
 			helper, err := connhelper.GetConnectionHelperWithSSHOpts(host, sshopts)
 			if err != nil {
 				return nil, err
@@ -949,4 +950,17 @@ func mapDockerignore(dockerfile string) string {
 	}
 	// Return the default dockerignore name.
 	return ignore
+}
+
+func SSHOptsToSlice(sshOptsFromConf string) []string {
+
+	trimmedOpts := strings.Trim(sshOptsFromConf, "[]")
+	slicedOpts := strings.Split(trimmedOpts, ",")
+	sshopts := []string{}
+
+	for _, val := range slicedOpts {
+		val = strings.ReplaceAll(val, "\"", "")
+		sshopts = append(sshopts, val)
+	}
+	return sshopts
 }

--- a/provider/image.go
+++ b/provider/image.go
@@ -851,7 +851,7 @@ func configureDockerClientInner(configs map[string]string, host string) (*client
 		// No TLS certificate material provided, create an http client
 		if host != "" {
 			var sshopts []string
-			if opts, ok := configs["sshOpts]"]; ok {
+			if opts, ok := configs["sshOpts"]; ok {
 				err = json.Unmarshal([]byte(opts), &sshopts)
 				if err != nil {
 					return nil, err

--- a/provider/image.go
+++ b/provider/image.go
@@ -850,7 +850,10 @@ func configureDockerClientInner(configs map[string]string, host string) (*client
 	} else {
 		// No TLS certificate material provided, create an http client
 		if host != "" {
-			sshopts := SSHOptsToSlice(configs["sshOpts"])
+			var sshopts []string
+			if opts, ok := configs["sshOpts]"]; ok {
+				json.Unmarshal([]byte(opts), &sshopts)
+			}
 			// first, check for ssh host
 			helper, err := connhelper.GetConnectionHelperWithSSHOpts(host, sshopts)
 			if err != nil {
@@ -950,17 +953,4 @@ func mapDockerignore(dockerfile string) string {
 	}
 	// Return the default dockerignore name.
 	return ignore
-}
-
-func SSHOptsToSlice(sshOptsFromConf string) []string {
-
-	trimmedOpts := strings.Trim(sshOptsFromConf, "[]")
-	slicedOpts := strings.Split(trimmedOpts, ",")
-	sshopts := []string{}
-
-	for _, val := range slicedOpts {
-		val = strings.ReplaceAll(val, "\"", "")
-		sshopts = append(sshopts, val)
-	}
-	return sshopts
 }

--- a/provider/image.go
+++ b/provider/image.go
@@ -852,7 +852,10 @@ func configureDockerClientInner(configs map[string]string, host string) (*client
 		if host != "" {
 			var sshopts []string
 			if opts, ok := configs["sshOpts]"]; ok {
-				json.Unmarshal([]byte(opts), &sshopts)
+				err = json.Unmarshal([]byte(opts), &sshopts)
+				if err != nil {
+					return nil, err
+				}
 			}
 			// first, check for ssh host
 			helper, err := connhelper.GetConnectionHelperWithSSHOpts(host, sshopts)

--- a/provider/image.go
+++ b/provider/image.go
@@ -852,7 +852,7 @@ func configureDockerClientInner(configs map[string]string, host string) (*client
 		if host != "" {
 			var sshopts []string
 			if opts, ok := configs["sshOpts"]; ok {
-				err = json.Unmarshal([]byte(opts), &sshopts)
+				err := json.Unmarshal([]byte(opts), &sshopts)
 				if err != nil {
 					return nil, err
 				}

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -552,19 +552,3 @@ func TestMapDockerignore(t *testing.T) {
 	})
 
 }
-
-func TestSSHOptsToSlice(t *testing.T) {
-	// The input for this test was taken from the config input returned by pulumirpc's req.GetVariables.
-	// It flattens the sshOpts config input into a string representation with escape characters.
-	t.Run("Properly normalizes flattened sshOpts configs input", func(t *testing.T) {
-		expected := []string{
-			"-l", "pulumipus",
-			"-i", "/Users/pulumipus/secret/.ssh/id_rsa",
-			"-o", "StrictHostKeyChecking=yes",
-			"-o", "UserKnownHostsFile=/dev/null"}
-		input := "[\"-l\",\"pulumipus\",\"-i\",\"/Users/pulumipus/secret/.ssh/id_rsa\"," +
-			"\"-o\",\"StrictHostKeyChecking=yes\",\"-o\",\"UserKnownHostsFile=/dev/null\"]"
-		actual := SSHOptsToSlice(input)
-		assert.Equal(t, expected, actual)
-	})
-}

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -552,3 +552,19 @@ func TestMapDockerignore(t *testing.T) {
 	})
 
 }
+
+func TestSSHOptsToSlice(t *testing.T) {
+	// The input for this test was taken from the config input returned by pulumirpc's req.GetVariables.
+	// It flattens the sshOpts config input into a string representation with escape characters.
+	t.Run("Properly normalizes flattened sshOpts configs input", func(t *testing.T) {
+		expected := []string{
+			"-l", "pulumipus",
+			"-i", "/Users/pulumipus/secret/.ssh/id_rsa",
+			"-o", "StrictHostKeyChecking=yes",
+			"-o", "UserKnownHostsFile=/dev/null"}
+		input := "[\"-l\",\"pulumipus\",\"-i\",\"/Users/pulumipus/secret/.ssh/id_rsa\"," +
+			"\"-o\",\"StrictHostKeyChecking=yes\",\"-o\",\"UserKnownHostsFile=/dev/null\"]"
+		actual := SSHOptsToSlice(input)
+		assert.Equal(t, expected, actual)
+	})
+}


### PR DESCRIPTION
Pulumirpc's req.GetVariables flattens the configs into strings, even though `sshOpts` is properly a slice of strings. Worse, we get all sorts of extra escape characters. 

This pull request unmarshals `sshOpts` when needed and passes the resulting ssh flag options to the SSH connection helper.

Additionally, we set up a TS test for a remote Docker host using a Digitalocean Docker Droplet.

To make this work, there are some changes to the acceptance tests Workflow as well. This PR will need a followup in ci-mgmt to incorporate these changes properly.

This PR needs follow-up changes to ci-mgmt to 

Fixes #702.

- Read in SSH flags to the connection helper to avoid error in Configure
- Add integration test for SSH connections
