### PR TITLE
Fix: docker host connection for SSH

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -762,6 +762,14 @@ func configureDockerClient(configs map[string]string, verify bool) (*client.Clie
 		return cli, nil
 	}
 
+	// Skip checking connection for SSH.
+	// When a user uses an SSH-based client, we do not want to fall back on default hosts.
+	// Additionally, due to https://github.com/kreuzwerker/terraform-provider-docker/issues/262,
+	// we want to limit making connections to our remote host.
+	if cli.DaemonHost() == "http://docker.example.com" {
+		return cli, err
+	}
+
 	// Check if the connection works. If not and we used the default host, try the user host.
 	// See "Adminless install on macOS" on https://www.docker.com/blog/docker-desktop-4-18/
 	log.Printf("checking connection to docker daemon at %s", host)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -90,8 +90,14 @@ func (p *dockerNativeProvider) Configure(_ context.Context, req *rpc.ConfigureRe
 		return nil, err
 	}
 	host := client.DaemonHost()
-	log.Printf("Setting DOCKER_HOST to %s", host)
-	os.Setenv("DOCKER_HOST", host)
+
+	// In the case of a remote docker client that we connect to with SSH, we use a connection helper as the daemon host.
+	// Per the docker/cli/cli/connhelper package, this is hardcoded as http://docker.example.com for SSH.
+	// If we are using a remote host via SSH, we do NOT want to overwrite DOCKER_HOST here.
+	if host != "http://docker.example.com" {
+		log.Printf("Setting DOCKER_HOST to %s", host)
+		os.Setenv("DOCKER_HOST", host)
+	}
 
 	return &rpc.ConfigureResponse{}, nil
 }


### PR DESCRIPTION
In #697, we added logic to Configure to determine and set the docker host address.
Because SSH uses a connection helper, in this PR we check for the connection helper string, and do not re-set DOCKER_HOST.

I verified this fixes the user-provided bug repro submitted with #706.

Fixes #706
