### PR TITLE
Make repoDigest return for local image builds

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -222,6 +222,21 @@ func TestSSHConnNode(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestLocalRepoDigestNode(t *testing.T) {
+	test := getJsOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "test-local-repo-digest-ts"),
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				repoDigest, ok := stack.Outputs["repoDigest"]
+				assert.True(t, ok)
+				assert.NotEmpty(t, repoDigest)
+			},
+			Quick:       true,
+			SkipRefresh: true,
+		})
+	integration.ProgramTest(t, &test)
+}
+
 func getJsOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions()
 	baseJs := base.With(integration.ProgramTestOptions{

--- a/examples/test-local-repo-digest-ts/Dockerfile
+++ b/examples/test-local-repo-digest-ts/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu
+RUN echo "Hello from Pulumi Testing!"

--- a/examples/test-local-repo-digest-ts/Pulumi.yaml
+++ b/examples/test-local-repo-digest-ts/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: test-local-repo-digest-ts
+runtime: nodejs
+description: A minimal TypeScript Pulumi program
+template:
+  description: A minimal TypeScript Pulumi program

--- a/examples/test-local-repo-digest-ts/index.ts
+++ b/examples/test-local-repo-digest-ts/index.ts
@@ -1,0 +1,14 @@
+import * as docker from "@pulumi/docker";
+
+const localImg = new docker.Image("my-image", {
+    imageName: "pulumi-bot/local-repo-digest",
+    skipPush:true,
+    build: {
+        platform: "linux/amd64",
+    }
+});
+
+export const imageName = localImg.imageName;
+
+export const repoDigest = localImg.repoDigest
+

--- a/examples/test-local-repo-digest-ts/package.json
+++ b/examples/test-local-repo-digest-ts/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "test-local-repo-digest-ts",
+    "devDependencies": {
+        "@types/node": "^16"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0"
+    }
+}

--- a/examples/test-local-repo-digest-ts/tsconfig.json
+++ b/examples/test-local-repo-digest-ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.ts"
+    ]
+}

--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -3049,7 +3049,7 @@
                 },
                 "repoDigest": {
                     "type": "string",
-                    "description": "The manifest digest of an image pushed to a registry, of the format repository@\u003calgorithm\u003e:\u003chash\u003e, e.g. `username/demo-image@sha256:a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.\nThis reference is unique per image build and push. \nOnly available for images pushed to a registry.\nUse when passing a reference to a pushed image to container management resources."
+                    "description": "**For pushed images:**\nThe manifest digest of an image pushed to a registry, of the format repository@\u003calgorithm\u003e:\u003chash\u003e, e.g. `username/demo-image@sha256:a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.\nThis reference is unique per image build and push. \nOnly available for images pushed to a registry.\nUse when passing a reference to a pushed image to container management resources.\n\n**Local-only images**For local images, this field is the image ID of the built local image, of the format \u003calgorithm\u003e:\u003chash\u003e, e.g `sha256:826a130323165bb0ccb0374ae774f885c067a951b51a6ee133577f4e5dbc4119` \n"
                 }
             },
             "type": "object",
@@ -3058,7 +3058,8 @@
                 "context",
                 "baseImageName",
                 "registryServer",
-                "imageName"
+                "imageName",
+                "repoDigest"
             ],
             "inputProperties": {
                 "build": {
@@ -3067,7 +3068,7 @@
                 },
                 "imageName": {
                     "type": "string",
-                    "description": "The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.\nThis reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`."
+                    "description": "The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.\nThis reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`."
                 },
                 "registry": {
                     "$ref": "#/types/docker:index/registry:Registry",

--- a/provider/image.go
+++ b/provider/image.go
@@ -329,6 +329,13 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 
 	// if we are not pushing to the registry, we return after building the local image.
 	if img.SkipPush {
+		// Obtain image digest from docker inspect
+		imageInspect, _, inspErr := docker.ImageInspectWithRaw(ctx, img.Name)
+		if inspErr != nil {
+			return "", nil, err
+		}
+		// We set repoDigest to the image ID returned from docker inspect.
+		outputs["repoDigest"] = imageInspect.ID
 		pbstruct, err := plugin.MarshalProperties(
 			resource.NewPropertyMapFromMap(outputs),
 			plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -232,7 +232,7 @@ func Provider() tfbridge.ProviderInfo {
 					Type:        "object",
 					Description: docImage,
 					Required: []string{
-						"dockerfile", "context", "baseImageName", "registryServer", "imageName",
+						"dockerfile", "context", "baseImageName", "registryServer", "imageName", "repoDigest",
 					},
 					Properties: map[string]schema.PropertySpec{
 						"imageName": {
@@ -256,12 +256,17 @@ func Provider() tfbridge.ProviderInfo {
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 						},
 						"repoDigest": {
-							Description: "The manifest digest of an image pushed to a registry, of the format " +
+							Description: "**For pushed images:**\n" +
+								"The manifest digest of an image pushed to a registry, of the format " +
 								"repository@<algorithm>:<hash>, e.g. `username/demo-image@sha256:" +
 								"a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.\n" +
 								"This reference is unique per image build and push. \n" +
 								"Only available for images pushed to a registry.\n" +
-								"Use when passing a reference to a pushed image to container management resources.",
+								"Use when passing a reference to a pushed image to container management resources.\n\n" +
+								"**Local-only images**" +
+								"For local images, this field is the image ID of the built local image, of the format " +
+								"<algorithm>:<hash>, " +
+								"e.g `sha256:826a130323165bb0ccb0374ae774f885c067a951b51a6ee133577f4e5dbc4119` \n",
 							TypeSpec: schema.TypeSpec{Type: "string"},
 						},
 					},
@@ -272,7 +277,8 @@ func Provider() tfbridge.ProviderInfo {
 						Description: "The image name, of the format repository[:tag], " +
 							"e.g. `docker.io/username/demo-image:v1`.\n" +
 							"This reference is not unique to each build and push." +
-							"For the unique manifest SHA of a pushed docker image, please use `repoDigest`.",
+							"For the unique manifest SHA of a pushed docker image, or the local image ID, " +
+							"please use `repoDigest`.",
 						TypeSpec: schema.TypeSpec{Type: "string"},
 					},
 					"registry": {

--- a/sdk/dotnet/Image.cs
+++ b/sdk/dotnet/Image.cs
@@ -184,13 +184,16 @@ namespace Pulumi.Docker
         public Output<string> RegistryServer { get; private set; } = null!;
 
         /// <summary>
+        /// **For pushed images:**
         /// The manifest digest of an image pushed to a registry, of the format repository@&lt;algorithm&gt;:&lt;hash&gt;, e.g. `username/demo-image@sha256:a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.
         /// This reference is unique per image build and push. 
         /// Only available for images pushed to a registry.
         /// Use when passing a reference to a pushed image to container management resources.
+        /// 
+        /// **Local-only images**For local images, this field is the image ID of the built local image, of the format &lt;algorithm&gt;:&lt;hash&gt;, e.g `sha256:826a130323165bb0ccb0374ae774f885c067a951b51a6ee133577f4e5dbc4119` 
         /// </summary>
         [Output("repoDigest")]
-        public Output<string?> RepoDigest { get; private set; } = null!;
+        public Output<string> RepoDigest { get; private set; } = null!;
 
 
         /// <summary>
@@ -249,7 +252,7 @@ namespace Pulumi.Docker
 
         /// <summary>
         /// The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-        /// This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+        /// This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
         /// </summary>
         [Input("imageName", required: true)]
         public Input<string> ImageName { get; set; } = null!;

--- a/sdk/go/docker/image.go
+++ b/sdk/go/docker/image.go
@@ -174,11 +174,14 @@ type Image struct {
 	ImageName pulumi.StringOutput `pulumi:"imageName"`
 	// The name of the registry server hosting the image.
 	RegistryServer pulumi.StringOutput `pulumi:"registryServer"`
+	// **For pushed images:**
 	// The manifest digest of an image pushed to a registry, of the format repository@<algorithm>:<hash>, e.g. `username/demo-image@sha256:a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.
 	// This reference is unique per image build and push.
 	// Only available for images pushed to a registry.
 	// Use when passing a reference to a pushed image to container management resources.
-	RepoDigest pulumi.StringPtrOutput `pulumi:"repoDigest"`
+	//
+	// **Local-only images**For local images, this field is the image ID of the built local image, of the format <algorithm>:<hash>, e.g `sha256:826a130323165bb0ccb0374ae774f885c067a951b51a6ee133577f4e5dbc4119`
+	RepoDigest pulumi.StringOutput `pulumi:"repoDigest"`
 }
 
 // NewImage registers a new resource with the given unique name, arguments, and options.
@@ -238,7 +241,7 @@ type imageArgs struct {
 	// The Docker build context
 	Build *DockerBuild `pulumi:"build"`
 	// The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-	// This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+	// This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
 	ImageName string `pulumi:"imageName"`
 	// The registry to push the image to
 	Registry *Registry `pulumi:"registry"`
@@ -251,7 +254,7 @@ type ImageArgs struct {
 	// The Docker build context
 	Build DockerBuildPtrInput
 	// The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-	// This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+	// This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
 	ImageName pulumi.StringInput
 	// The registry to push the image to
 	Registry RegistryPtrInput
@@ -371,12 +374,15 @@ func (o ImageOutput) RegistryServer() pulumi.StringOutput {
 	return o.ApplyT(func(v *Image) pulumi.StringOutput { return v.RegistryServer }).(pulumi.StringOutput)
 }
 
+// **For pushed images:**
 // The manifest digest of an image pushed to a registry, of the format repository@<algorithm>:<hash>, e.g. `username/demo-image@sha256:a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.
 // This reference is unique per image build and push.
 // Only available for images pushed to a registry.
 // Use when passing a reference to a pushed image to container management resources.
-func (o ImageOutput) RepoDigest() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Image) pulumi.StringPtrOutput { return v.RepoDigest }).(pulumi.StringPtrOutput)
+//
+// **Local-only images**For local images, this field is the image ID of the built local image, of the format <algorithm>:<hash>, e.g `sha256:826a130323165bb0ccb0374ae774f885c067a951b51a6ee133577f4e5dbc4119`
+func (o ImageOutput) RepoDigest() pulumi.StringOutput {
+	return o.ApplyT(func(v *Image) pulumi.StringOutput { return v.RepoDigest }).(pulumi.StringOutput)
 }
 
 type ImageArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/docker/Image.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/Image.java
@@ -12,7 +12,6 @@ import com.pulumi.docker.ImageArgs;
 import com.pulumi.docker.Utilities;
 import java.lang.String;
 import java.util.List;
-import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -249,24 +248,30 @@ public class Image extends com.pulumi.resources.CustomResource {
         return this.registryServer;
     }
     /**
+     * **For pushed images:**
      * The manifest digest of an image pushed to a registry, of the format repository@&lt;algorithm&gt;:&lt;hash&gt;, e.g. `username/demo-image@sha256:a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.
      * This reference is unique per image build and push.
      * Only available for images pushed to a registry.
      * Use when passing a reference to a pushed image to container management resources.
      * 
+     * **Local-only images**For local images, this field is the image ID of the built local image, of the format &lt;algorithm&gt;:&lt;hash&gt;, e.g `sha256:826a130323165bb0ccb0374ae774f885c067a951b51a6ee133577f4e5dbc4119`
+     * 
      */
     @Export(name="repoDigest", type=String.class, parameters={})
-    private Output</* @Nullable */ String> repoDigest;
+    private Output<String> repoDigest;
 
     /**
-     * @return The manifest digest of an image pushed to a registry, of the format repository@&lt;algorithm&gt;:&lt;hash&gt;, e.g. `username/demo-image@sha256:a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.
+     * @return **For pushed images:**
+     * The manifest digest of an image pushed to a registry, of the format repository@&lt;algorithm&gt;:&lt;hash&gt;, e.g. `username/demo-image@sha256:a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.
      * This reference is unique per image build and push.
      * Only available for images pushed to a registry.
      * Use when passing a reference to a pushed image to container management resources.
      * 
+     * **Local-only images**For local images, this field is the image ID of the built local image, of the format &lt;algorithm&gt;:&lt;hash&gt;, e.g `sha256:826a130323165bb0ccb0374ae774f885c067a951b51a6ee133577f4e5dbc4119`
+     * 
      */
-    public Output<Optional<String>> repoDigest() {
-        return Codegen.optional(this.repoDigest);
+    public Output<String> repoDigest() {
+        return this.repoDigest;
     }
 
     /**

--- a/sdk/java/src/main/java/com/pulumi/docker/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/ImageArgs.java
@@ -36,7 +36,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-     * This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+     * This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
      * 
      */
     @Import(name="imageName", required=true)
@@ -44,7 +44,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
 
     /**
      * @return The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-     * This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+     * This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
      * 
      */
     public Output<String> imageName() {
@@ -131,7 +131,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param imageName The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-         * This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+         * This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
          * 
          * @return builder
          * 
@@ -143,7 +143,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param imageName The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-         * This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+         * This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/image.ts
+++ b/sdk/nodejs/image.ts
@@ -150,12 +150,15 @@ export class Image extends pulumi.CustomResource {
      */
     public /*out*/ readonly registryServer!: pulumi.Output<string>;
     /**
+     * **For pushed images:**
      * The manifest digest of an image pushed to a registry, of the format repository@<algorithm>:<hash>, e.g. `username/demo-image@sha256:a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.
      * This reference is unique per image build and push. 
      * Only available for images pushed to a registry.
      * Use when passing a reference to a pushed image to container management resources.
+     *
+     * **Local-only images**For local images, this field is the image ID of the built local image, of the format <algorithm>:<hash>, e.g `sha256:826a130323165bb0ccb0374ae774f885c067a951b51a6ee133577f4e5dbc4119` 
      */
-    public /*out*/ readonly repoDigest!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly repoDigest!: pulumi.Output<string>;
 
     /**
      * Create a Image resource with the given unique name, arguments, and options.
@@ -205,7 +208,7 @@ export interface ImageArgs {
     build?: pulumi.Input<inputs.DockerBuild>;
     /**
      * The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-     * This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+     * This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
      */
     imageName: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_docker/image.py
+++ b/sdk/python/pulumi_docker/image.py
@@ -23,7 +23,7 @@ class ImageArgs:
         """
         The set of arguments for constructing a Image resource.
         :param pulumi.Input[str] image_name: The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-               This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+               This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
         :param pulumi.Input['DockerBuildArgs'] build: The Docker build context
         :param pulumi.Input['RegistryArgs'] registry: The registry to push the image to
         :param pulumi.Input[bool] skip_push: A flag to skip a registry push.
@@ -43,7 +43,7 @@ class ImageArgs:
     def image_name(self) -> pulumi.Input[str]:
         """
         The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-        This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+        This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
         """
         return pulumi.get(self, "image_name")
 
@@ -189,7 +189,7 @@ class Image(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[pulumi.InputType['DockerBuildArgs']] build: The Docker build context
         :param pulumi.Input[str] image_name: The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
-               This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, please use `repoDigest`.
+               This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
         :param pulumi.Input[pulumi.InputType['RegistryArgs']] registry: The registry to push the image to
         :param pulumi.Input[bool] skip_push: A flag to skip a registry push.
         """
@@ -401,12 +401,15 @@ class Image(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="repoDigest")
-    def repo_digest(self) -> pulumi.Output[Optional[str]]:
+    def repo_digest(self) -> pulumi.Output[str]:
         """
+        **For pushed images:**
         The manifest digest of an image pushed to a registry, of the format repository@<algorithm>:<hash>, e.g. `username/demo-image@sha256:a6ae6dd8d39c5bb02320e41abf00cd4cb35905fec540e37d306c878be8d38bd3`.
         This reference is unique per image build and push. 
         Only available for images pushed to a registry.
         Use when passing a reference to a pushed image to container management resources.
+
+        **Local-only images**For local images, this field is the image ID of the built local image, of the format <algorithm>:<hash>, e.g `sha256:826a130323165bb0ccb0374ae774f885c067a951b51a6ee133577f4e5dbc4119` 
         """
         return pulumi.get(self, "repo_digest")
 


### PR DESCRIPTION
This pull request adds logic to inspect a recently built, local docker image, and uses its ID field to populate the `repoDigest` output for local images.
This value is the same as the "IMAGE ID" output from `docker images`, and it can be used, by itself, to run a container.
This extra logic allows us to additionally make repoDigest Required, making it far more straightforward to use.
Because the shape of this Output is slightly different depending on whether we're populating a pushed image vs a purely local one, the difference is documented.
Overall, this should address usability concerns for this field on pushed images as well.

Fixes #728

- Obtain image ID for local image from docker inspect object, and use it to set repoDigest for local images
- Make repoDigest Required and update documentation
- Generate schema and SDKs
- Add test to verify a local image build returns a repoDigest
