### PR TITLE
Attach to native provider for debugging

### DIFF
--- a/provider/hybrid.go
+++ b/provider/hybrid.go
@@ -35,6 +35,10 @@ const dockerImageTok = "docker:index/image:Image"
 // gRPC methods for the hybrid provider
 
 func (dp dockerHybridProvider) Attach(ctx context.Context, attach *rpc.PluginAttach) (*emptypb.Empty, error) {
+	_, err := dp.bridgedProvider.Attach(ctx, attach)
+	if err != nil {
+		return nil, err
+	}
 	return dp.nativeProvider.Attach(ctx, attach)
 }
 

--- a/provider/hybrid.go
+++ b/provider/hybrid.go
@@ -35,8 +35,7 @@ const dockerImageTok = "docker:index/image:Image"
 // gRPC methods for the hybrid provider
 
 func (dp dockerHybridProvider) Attach(ctx context.Context, attach *rpc.PluginAttach) (*emptypb.Empty, error) {
-	//TODO implement me
-	panic("implement me")
+	return dp.nativeProvider.Attach(ctx, attach)
 }
 
 func (dp dockerHybridProvider) Call(ctx context.Context, request *rpc.CallRequest) (*rpc.CallResponse, error) {


### PR DESCRIPTION
I figure that's the most likely use case, debugging our own code rather than upstream.

Tested locally.