### PR TITLE
Mark __inputs as secret

### DIFF
--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -65,6 +65,12 @@ func TestSecretsYAML(t *testing.T) {
 			imgNameStr, err := json.Marshal(imgName)
 			assert.NoError(t, err)
 			assert.NotContains(t, imgNameStr, "pulumibot/test-secrets:yaml")
+
+			// Make sure that state file does not contain secrets in plain.
+			deploymentJSON, err := json.MarshalIndent(stack.Deployment, "", "  ")
+			assert.NoError(t, err)
+			assert.NotContainsf(t, string(deploymentJSON), "supersecret",
+				"Secret should not be stored in the plain state")
 		},
 	})
 }

--- a/provider/image.go
+++ b/provider/image.go
@@ -784,10 +784,10 @@ func configureDockerClient(configs map[string]string, verify bool) (*client.Clie
 		if err != nil {
 			log.Printf("error connecting to docker daemon at %s: %v", cli.DaemonHost(), err)
 			return false
-		} else {
-			log.Printf("successful connection to docker daemon at %s", cli.DaemonHost())
-			return true
 		}
+
+		log.Printf("successful connection to docker daemon at %s", cli.DaemonHost())
+		return true
 	}
 
 	success := testConnection(cli)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -347,6 +347,7 @@ func (p *dockerNativeProvider) Create(ctx context.Context, req *rpc.CreateReques
 		checkpointObject(inputs, outputs.Mappable()),
 		plugin.MarshalOptions{
 			Label:        fmt.Sprintf("%s.checkpoint", label),
+			KeepSecrets:  true,
 			KeepUnknowns: true,
 			SkipNulls:    true,
 		},
@@ -410,6 +411,7 @@ func (p *dockerNativeProvider) Update(ctx context.Context, req *rpc.UpdateReques
 		checkpointObject(newInputs, outputs.Mappable()),
 		plugin.MarshalOptions{
 			Label:        fmt.Sprintf("%s.checkpoint", label),
+			KeepSecrets:  true,
 			KeepUnknowns: true,
 			SkipNulls:    true,
 		},


### PR DESCRIPTION
Fix #772 by enabling `KeepSecrets` in checkpoint encoding.

Adjusted an existing test to validate state file, test failure before the fix can be seen here: https://github.com/pulumi/pulumi-docker/actions/runs/6406254044/job/17390696422#step:27:685