### PR TITLE
Adjust diffUpdates to allow unknown values in preview

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -287,16 +287,15 @@ func (p *dockerNativeProvider) Diff(ctx context.Context, req *rpc.DiffRequest) (
 func diffUpdates(updates map[resource.PropertyKey]resource.ValueDiff) map[string]*rpc.PropertyDiff {
 	updateDiff := map[string]*rpc.PropertyDiff{}
 	for key, valueDiff := range updates {
-		skipUpdate := false
+		update := true
 
 		if string(key) == "registry" && valueDiff.Object != nil {
 			// only register a diff on "server" field, but not on "username" or "password",
 			// as they can change frequently and should not trigger a rebuild.
-			_, hasServer := valueDiff.Object.Updates["server"]
-			skipUpdate = !hasServer
+			_, update = valueDiff.Object.Updates["server"]
 		}
 
-		if !skipUpdate {
+		if update {
 			updateDiff[string(key)] = &rpc.PropertyDiff{
 				Kind: rpc.PropertyDiff_UPDATE,
 			}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -287,19 +287,18 @@ func (p *dockerNativeProvider) Diff(ctx context.Context, req *rpc.DiffRequest) (
 func diffUpdates(updates map[resource.PropertyKey]resource.ValueDiff) map[string]*rpc.PropertyDiff {
 	updateDiff := map[string]*rpc.PropertyDiff{}
 	for key, valueDiff := range updates {
-		if string(key) != "registry" {
-			updateDiff[string(key)] = &rpc.PropertyDiff{
-				Kind: rpc.PropertyDiff_UPDATE,
-			}
-		} else {
+		skipUpdate := false
+
+		if string(key) == "registry" && valueDiff.Object != nil {
 			// only register a diff on "server" field, but not on "username" or "password",
 			// as they can change frequently and should not trigger a rebuild.
-			serverDiff := valueDiff.Object.Updates["server"]
-			// if serverDiff is not empty, we register a property diff update
-			if serverDiff != (resource.ValueDiff{}) {
-				updateDiff[string(key)] = &rpc.PropertyDiff{
-					Kind: rpc.PropertyDiff_UPDATE,
-				}
+			_, hasServer := valueDiff.Object.Updates["server"]
+			skipUpdate = !hasServer
+		}
+
+		if !skipUpdate {
+			updateDiff[string(key)] = &rpc.PropertyDiff{
+				Kind: rpc.PropertyDiff_UPDATE,
 			}
 		}
 	}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -82,6 +82,26 @@ func TestDiffUpdates(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
+	t.Run("Diff happens on unknown new registry", func(t *testing.T) {
+		expected := map[string]*rpc.PropertyDiff{
+			"registry": {
+				Kind: rpc.PropertyDiff_UPDATE,
+			},
+		}
+		input := map[resource.PropertyKey]resource.ValueDiff{
+			"registry": {
+				Old: resource.NewObjectProperty(resource.PropertyMap{
+					"server":   resource.NewStringProperty("https://index.docker.io/v1/"),
+					"username": resource.NewStringProperty("pulumipus"),
+					"password": resource.NewStringProperty("supersecret"),
+				}),
+				New: resource.NewComputedProperty(resource.Computed{Element: resource.NewStringProperty("X")}),
+			},
+		}
+		actual := diffUpdates(input)
+		assert.Equal(t, expected, actual)
+	})
+
 	t.Run("Diff happens on changed build context", func(t *testing.T) {
 		expected := map[string]*rpc.PropertyDiff{
 			"build": {


### PR DESCRIPTION
Fix https://github.com/pulumi/pulumi-docker/issues/780

When `registry` input relies on unknown outputs, the `diffUpdates` function currently panics. I added a test for this use case and reshuffled `diffUpdates` implementation to handle it properly and hopefully a bit more clearly.