### PR TITLE
Prevent unknown inflection in build

### DIFF
--- a/examples/aws-container-registry/ts/index.ts
+++ b/examples/aws-container-registry/ts/index.ts
@@ -1,5 +1,6 @@
 import * as aws from "@pulumi/aws";
 import * as docker from "@pulumi/docker";
+import * as random from "@pulumi/random";
 
 // Create a private ECR registry.
 const repo = new aws.ecr.Repository("my-repo",{
@@ -21,10 +22,16 @@ const registryInfo = repo.registryId.apply(async id => {
     };
 });
 
+
 // Build and publish the image.
 const image = new docker.Image("my-image", {
     build: {
-        context: "app"
+        context: "app",
+        args: {
+            // Test for preview with dymanic build property.
+            // See https://github.com/pulumi/pulumi-docker/issues/620
+            KEY: new random.RandomUuid('guid', {}).result,
+        },
     },
     imageName: repo.repositoryUrl,
     registry: registryInfo,

--- a/examples/aws-container-registry/ts/package.json
+++ b/examples/aws-container-registry/ts/package.json
@@ -5,6 +5,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/aws": "latest"
+        "@pulumi/aws": "latest",
+        "@pulumi/random": "latest"
     }
 }

--- a/examples/azure-container-registry/ts/step2/index.ts
+++ b/examples/azure-container-registry/ts/step2/index.ts
@@ -4,7 +4,7 @@ import * as pulumi from "@pulumi/pulumi";
 
 // Create a private ACR registry.
 const rg = new azure.core.ResourceGroup("myrg")
-const registry = new azure.containerservice.Registry("myregistry", {
+const registry = new azure.containerservice.Registry("myotherregistry", { // <-- renamed the registry to cause a replacement
     resourceGroupName: rg.name,
     adminEnabled: true,
     sku: "Basic",

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -60,6 +60,12 @@ func TestAzureContainerRegistry(t *testing.T) {
 				"azure:location":    location,
 			},
 			ExpectRefreshChanges: true,
+			EditDirs: []integration.EditDir{
+				{
+					Dir:      "step2",
+					Additive: true,
+				},
+			},
 		})
 
 	integration.ProgramTest(t, &test)

--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -1785,8 +1785,7 @@
                 },
                 "builderVersion": {
                     "$ref": "#/types/docker:index/builderVersion:BuilderVersion",
-                    "description": "The version of the Docker builder.",
-                    "default": "BuilderBuildKit"
+                    "description": "The version of the Docker builder."
                 },
                 "cacheFrom": {
                     "$ref": "#/types/docker:index/cacheFrom:CacheFrom",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -185,7 +185,6 @@ func Provider() tfbridge.ProviderInfo {
 							TypeSpec: schema.TypeSpec{
 								Ref: "#/types/docker:index/builderVersion:BuilderVersion",
 							},
-							Default: "BuilderBuildKit",
 						},
 						"platform": {
 							Description: "The architecture of the platform you want to build this image for, " +

--- a/sdk/dotnet/Inputs/DockerBuildArgs.cs
+++ b/sdk/dotnet/Inputs/DockerBuildArgs.cs
@@ -65,7 +65,6 @@ namespace Pulumi.Docker.Inputs
 
         public DockerBuildArgs()
         {
-            BuilderVersion = Pulumi.Docker.BuilderVersion.BuilderBuildKit;
         }
         public static new DockerBuildArgs Empty => new DockerBuildArgs();
     }

--- a/sdk/go/docker/image.go
+++ b/sdk/go/docker/image.go
@@ -196,9 +196,6 @@ func NewImage(ctx *pulumi.Context,
 	if args.ImageName == nil {
 		return nil, errors.New("invalid value for required argument 'ImageName'")
 	}
-	if args.Build != nil {
-		args.Build = args.Build.ToDockerBuildPtrOutput().ApplyT(func(v *DockerBuild) *DockerBuild { return v.Defaults() }).(DockerBuildPtrOutput)
-	}
 	if args.SkipPush == nil {
 		args.SkipPush = pulumi.BoolPtr(false)
 	}

--- a/sdk/go/docker/pulumiTypes.go
+++ b/sdk/go/docker/pulumiTypes.go
@@ -11013,19 +11013,6 @@ type DockerBuild struct {
 	Target *string `pulumi:"target"`
 }
 
-// Defaults sets the appropriate defaults for DockerBuild
-func (val *DockerBuild) Defaults() *DockerBuild {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if tmp.BuilderVersion == nil {
-		builderVersion_ := BuilderVersion("BuilderBuildKit")
-		tmp.BuilderVersion = &builderVersion_
-	}
-	return &tmp
-}
-
 // DockerBuildInput is an input type that accepts DockerBuildArgs and DockerBuildOutput values.
 // You can construct a concrete instance of `DockerBuildInput` via:
 //
@@ -11055,17 +11042,6 @@ type DockerBuildArgs struct {
 	Target pulumi.StringPtrInput `pulumi:"target"`
 }
 
-// Defaults sets the appropriate defaults for DockerBuildArgs
-func (val *DockerBuildArgs) Defaults() *DockerBuildArgs {
-	if val == nil {
-		return nil
-	}
-	tmp := *val
-	if tmp.BuilderVersion == nil {
-		tmp.BuilderVersion = BuilderVersion("BuilderBuildKit")
-	}
-	return &tmp
-}
 func (DockerBuildArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*DockerBuild)(nil)).Elem()
 }

--- a/sdk/java/src/main/java/com/pulumi/docker/inputs/DockerBuildArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/inputs/DockerBuildArgs.java
@@ -5,7 +5,6 @@ package com.pulumi.docker.inputs;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
-import com.pulumi.core.internal.Codegen;
 import com.pulumi.docker.enums.BuilderVersion;
 import com.pulumi.docker.inputs.CacheFromArgs;
 import java.lang.String;
@@ -306,7 +305,6 @@ public final class DockerBuildArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public DockerBuildArgs build() {
-            $.builderVersion = Codegen.objectProp("builderVersion", BuilderVersion.class).output().arg($.builderVersion).def(BuilderVersion.BuilderBuildKit).getNullable();
             return $;
         }
     }

--- a/sdk/nodejs/image.ts
+++ b/sdk/nodejs/image.ts
@@ -174,7 +174,7 @@ export class Image extends pulumi.CustomResource {
             if ((!args || args.imageName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'imageName'");
             }
-            resourceInputs["build"] = args ? (args.build ? pulumi.output(args.build).apply(inputs.dockerBuildProvideDefaults) : undefined) : undefined;
+            resourceInputs["build"] = args ? args.build : undefined;
             resourceInputs["imageName"] = args ? args.imageName : undefined;
             resourceInputs["registry"] = args ? args.registry : undefined;
             resourceInputs["skipPush"] = (args ? args.skipPush : undefined) ?? false;

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -6,8 +6,6 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 import * as enums from "../types/enums";
 
-import * as utilities from "../utilities";
-
 /**
  * Contains a list of images to reference when building using a cache
  */
@@ -293,15 +291,6 @@ export interface DockerBuild {
      * The target of the Dockerfile to build
      */
     target?: pulumi.Input<string>;
-}
-/**
- * dockerBuildProvideDefaults sets the appropriate defaults for DockerBuild
- */
-export function dockerBuildProvideDefaults(val: DockerBuild): DockerBuild {
-    return {
-        ...val,
-        builderVersion: (val.builderVersion) ?? "BuilderBuildKit",
-    };
 }
 
 export interface NetworkIpamConfig {

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -6,8 +6,6 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 import * as enums from "../types/enums";
 
-import * as utilities from "../utilities";
-
 export interface ContainerCapabilities {
     /**
      * List of linux capabilities to add.

--- a/sdk/python/pulumi_docker/_inputs.py
+++ b/sdk/python/pulumi_docker/_inputs.py
@@ -4030,8 +4030,6 @@ class DockerBuildArgs:
         """
         if args is not None:
             pulumi.set(__self__, "args", args)
-        if builder_version is None:
-            builder_version = 'BuilderBuildKit'
         if builder_version is not None:
             pulumi.set(__self__, "builder_version", builder_version)
         if cache_from is not None:


### PR DESCRIPTION
A somewhat bizarre fix for #676 

### Problem

Let me try to explain what is going on in #676. The relevant snippet is (same as in the new test):

```
const image = new docker.Image("my-image", {
    build: {
        context: "app",
        cacheFrom: {
            images: [imageName]
        },
    }
```

Where `imageName` depends on another resource R. In the problematic scenario, the resource R is being replaced, which turns `imageName` into unknown. Unfortunately, this turns the entire `build` object into a big unknown instead of the desired effect of it keeping its shape with only an unknown value inside `cacheFrom`.

Here is a gRPC log:

```
{"build":"04da6b54-80e4-46f7-96ec-b56ff0331ba9","imageName":"04da6b54-80e4-46f7-96ec-b56ff0331ba9","registry":{"password":"04da6b54-80e4-46f7-96ec-b56ff0331ba9","server":"04da6b54-80e4-46f7-96ec-b56ff0331ba9","username":"04da6b54-80e4-46f7-96ec-b56ff0331ba9"},"skipPush":false}
```

It turns out that `build` is unknown because of the current implementation of Node.js codegen that sets the parent object as unknown if that object needs a default value (see [here](https://github.com/pulumi/pulumi-docker/blob/24161acd0433b061e3b5acfa128b9ddb599b965b/sdk/nodejs/image.ts#L177)).

We then discard unknowns [here](https://github.com/pulumi/pulumi-docker/blob/24161acd0433b061e3b5acfa128b9ddb599b965b/provider/provider.go#L131) and proceed with filling default build properties in [`marshalBuildAndApplyDefaults`](https://github.com/pulumi/pulumi-docker/blob/24161acd0433b061e3b5acfa128b9ddb599b965b/provider/provider.go#L139), which causes the issue because `Dockerfile` is not available at its default location.

### Fix

We don't really need to set the default `builderVersion` value in the schema. We assume the same default value in [`marshalBuilder`](https://github.com/pulumi/pulumi-docker/blob/24161acd0433b061e3b5acfa128b9ddb599b965b/provider/image.go#L563) and cover this scenario with a few unit tests ([example](https://github.com/pulumi/pulumi-docker/blob/24161acd0433b061e3b5acfa128b9ddb599b965b/provider/image_test.go#L55)). Therefore, in this PR I chose to remove the default value from schema and SDKs and, as a side effect, avoid turning `build` into an unknown.

### Test

I tested it manually and adjusted the ACR test into a two-step test that exercises the scenario. You can see the test fail before my change [here](https://github.com/pulumi/pulumi-docker/actions/runs/6510330782/job/17684951125#step:27:166). Also added another test to validate #620.

Fix #676
Fix #620