### PR TITLE
Fix typo in `docker.getRemoteImage` documentation

### DIFF
--- a/sdk/python/pulumi_docker/get_remote_image.py
+++ b/sdk/python/pulumi_docker/get_remote_image.py
@@ -71,7 +71,7 @@ class AwaitableGetRemoteImageResult(GetRemoteImageResult):
 def get_remote_image(name: Optional[str] = None,
                      opts: Optional[pulumi.InvokeOptions] = None) -> AwaitableGetRemoteImageResult:
     """
-    `RemoteImage` provides details about a specific Docker Image which need to be presend on the Docker Host
+    `RemoteImage` provides details about a specific Docker Image which need to be present on the Docker Host
 
     ## Example Usage
 


### PR DESCRIPTION
Just a small typo fix :)