### PR TITLE
Fix Service replicated/global conflict

### DIFF
--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -91,7 +91,15 @@ func TestDockerSwarmYAML(t *testing.T) {
 		t.FailNow()
 	}
 
-	t.Run("replicated-service", func(t *testing.T) {
+	t.Run("service", func(t *testing.T) {
+		integration.ProgramTest(t, &integration.ProgramTestOptions{
+			Dir:         path.Join(cwd, "test-swarm", "service-global"),
+			Quick:       true,
+			SkipRefresh: true,
+		})
+	})
+
+	t.Run("service-replicated", func(t *testing.T) {
 		integration.ProgramTest(t, &integration.ProgramTestOptions{
 			Dir:         path.Join(cwd, "test-swarm", "service-replicated"),
 			Quick:       true,
@@ -99,7 +107,7 @@ func TestDockerSwarmYAML(t *testing.T) {
 		})
 	})
 
-	t.Run("global-service", func(t *testing.T) {
+	t.Run("service-global", func(t *testing.T) {
 		integration.ProgramTest(t, &integration.ProgramTestOptions{
 			Dir:         path.Join(cwd, "test-swarm", "service-global"),
 			Quick:       true,

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -93,7 +93,7 @@ func TestDockerSwarmYAML(t *testing.T) {
 
 	t.Run("service", func(t *testing.T) {
 		integration.ProgramTest(t, &integration.ProgramTestOptions{
-			Dir:         path.Join(cwd, "test-swarm", "service-global"),
+			Dir:         path.Join(cwd, "test-swarm", "service"),
 			Quick:       true,
 			SkipRefresh: true,
 		})
@@ -109,9 +109,9 @@ func TestDockerSwarmYAML(t *testing.T) {
 
 	t.Run("service-global", func(t *testing.T) {
 		integration.ProgramTest(t, &integration.ProgramTestOptions{
-			Dir:         path.Join(cwd, "test-swarm", "service-global"),
-			Quick:       true,
-			SkipRefresh: true,
+			Dir:        path.Join(cwd, "test-swarm", "service-global"),
+			Quick:      true,
+			kipRefresh: true,
 		})
 	})
 }

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -109,9 +109,9 @@ func TestDockerSwarmYAML(t *testing.T) {
 
 	t.Run("service-global", func(t *testing.T) {
 		integration.ProgramTest(t, &integration.ProgramTestOptions{
-			Dir:        path.Join(cwd, "test-swarm", "service-global"),
-			Quick:      true,
-			kipRefresh: true,
+			Dir:         path.Join(cwd, "test-swarm", "service-global"),
+			Quick:       true,
+			SkipRefresh: true,
 		})
 	})
 }

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -19,10 +19,12 @@ package examples
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
@@ -72,5 +74,36 @@ func TestSecretsYAML(t *testing.T) {
 			assert.NotContainsf(t, string(deploymentJSON), "supersecret",
 				"Secret should not be stored in the plain state")
 		},
+	})
+}
+
+func TestDockerSwarmYAML(t *testing.T) {
+	// Temporarily make ourselves a swarm manager.
+	cmd := exec.Command("docker", "swarm", "init")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	t.Cleanup(func() {
+		require.NoError(t, exec.Command("docker", "swarm", "leave", "--force").Run())
+	})
+
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	t.Run("replicated-service", func(t *testing.T) {
+		integration.ProgramTest(t, &integration.ProgramTestOptions{
+			Dir:         path.Join(cwd, "test-swarm", "service-replicated"),
+			Quick:       true,
+			SkipRefresh: true,
+		})
+	})
+
+	t.Run("global-service", func(t *testing.T) {
+		integration.ProgramTest(t, &integration.ProgramTestOptions{
+			Dir:         path.Join(cwd, "test-swarm", "service-global"),
+			Quick:       true,
+			SkipRefresh: true,
+		})
 	})
 }

--- a/examples/test-swarm/service-global/Pulumi.yaml
+++ b/examples/test-swarm/service-global/Pulumi.yaml
@@ -1,0 +1,11 @@
+name: docker-service-gloabl
+runtime: yaml
+resources:
+  service:
+    type: docker:Service
+    properties:
+      taskSpec:
+        containerSpec:
+          image: nginx
+      mode:
+        global: true

--- a/examples/test-swarm/service-replicated/Pulumi.yaml
+++ b/examples/test-swarm/service-replicated/Pulumi.yaml
@@ -1,0 +1,12 @@
+name: docker-service
+runtime: yaml
+resources:
+  service:
+    type: docker:Service
+    properties:
+      taskSpec:
+        containerSpec:
+          image: nginx
+      mode:
+        replicated:
+          replicas: 1

--- a/examples/test-swarm/service/Pulumi.yaml
+++ b/examples/test-swarm/service/Pulumi.yaml
@@ -1,4 +1,4 @@
-name: swarm-service-replicated
+name: swarm-service
 runtime: yaml
 resources:
   service:
@@ -7,6 +7,3 @@ resources:
       taskSpec:
         containerSpec:
           image: nginx
-      mode:
-        replicated:
-          replicas: 1

--- a/patches/0005-remove-service-default.patch
+++ b/patches/0005-remove-service-default.patch
@@ -6,8 +6,22 @@ index 577e81f..050453f 100644
 @@ -765,7 +765,6 @@ func resourceDockerService() *schema.Resource {
  						"global": {
  							Type:          schema.TypeBool,
- 							Description:   "The global service mode. Defaults to `false`",
+-							Description:   "The global service mode. Defaults to `false`",
++							Description:   "When `true`, tasks will run on every worker node. Conflicts with `replicated`",
 -							Default:       false,
  							Optional:      true,
  							ConflictsWith: []string{"mode.0.replicated", "converge_config"},
  						},
+diff --git a/docs/resources/service.md b/docs/resources/service.md
+index 496c93b..7ca972e 100644
+--- a/docs/resources/service.md
++++ b/docs/resources/service.md
+@@ -698,7 +698,7 @@ Required:
+
+ Optional:
+
+-- `global` (Boolean) The global service mode. Defaults to `false`
++- `global` (Boolean) When `true`, tasks will run on every worker node. Conflicts with `replicated`
+ - `replicated` (Block List, Max: 1) The replicated service mode (see [below for nested schema](#nestedblock--mode--replicated))
+
+ <a id="nestedblock--mode--replicated"></a>

--- a/patches/0005-remove-service-default.patch
+++ b/patches/0005-remove-service-default.patch
@@ -1,0 +1,13 @@
+# Workaround for https://github.com/pulumi/pulumi-terraform-bridge/issues/1095
+diff --git a/internal/provider/resource_docker_service.go b/internal/provider/resource_docker_service.go
+index 577e81f..050453f 100644
+--- a/internal/provider/resource_docker_service.go
++++ b/internal/provider/resource_docker_service.go
+@@ -765,7 +765,6 @@ func resourceDockerService() *schema.Resource {
+ 						"global": {
+ 							Type:          schema.TypeBool,
+ 							Description:   "The global service mode. Defaults to `false`",
+-							Default:       false,
+ 							Optional:      true,
+ 							ConflictsWith: []string{"mode.0.replicated", "converge_config"},
+ 						},

--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -1061,7 +1061,7 @@
             "properties": {
                 "global": {
                     "type": "boolean",
-                    "description": "The global service mode. Defaults to `false`\n"
+                    "description": "When `true`, tasks will run on every worker node. Conflicts with `replicated`\n"
                 },
                 "replicated": {
                     "$ref": "#/types/docker:index/ServiceModeReplicated:ServiceModeReplicated",

--- a/sdk/dotnet/Inputs/ServiceModeArgs.cs
+++ b/sdk/dotnet/Inputs/ServiceModeArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Docker.Inputs
     public sealed class ServiceModeArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// The global service mode. Defaults to `false`
+        /// When `true`, tasks will run on every worker node. Conflicts with `replicated`
         /// </summary>
         [Input("global")]
         public Input<bool>? Global { get; set; }

--- a/sdk/dotnet/Inputs/ServiceModeGetArgs.cs
+++ b/sdk/dotnet/Inputs/ServiceModeGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Docker.Inputs
     public sealed class ServiceModeGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// The global service mode. Defaults to `false`
+        /// When `true`, tasks will run on every worker node. Conflicts with `replicated`
         /// </summary>
         [Input("global")]
         public Input<bool>? Global { get; set; }

--- a/sdk/dotnet/Outputs/ServiceMode.cs
+++ b/sdk/dotnet/Outputs/ServiceMode.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Docker.Outputs
     public sealed class ServiceMode
     {
         /// <summary>
-        /// The global service mode. Defaults to `false`
+        /// When `true`, tasks will run on every worker node. Conflicts with `replicated`
         /// </summary>
         public readonly bool? Global;
         /// <summary>

--- a/sdk/go/docker/pulumiTypes.go
+++ b/sdk/go/docker/pulumiTypes.go
@@ -4575,7 +4575,7 @@ func (o ServiceLabelArrayOutput) Index(i pulumi.IntInput) ServiceLabelOutput {
 }
 
 type ServiceMode struct {
-	// The global service mode. Defaults to `false`
+	// When `true`, tasks will run on every worker node. Conflicts with `replicated`
 	Global *bool `pulumi:"global"`
 	// The replicated service mode
 	Replicated *ServiceModeReplicated `pulumi:"replicated"`
@@ -4593,7 +4593,7 @@ type ServiceModeInput interface {
 }
 
 type ServiceModeArgs struct {
-	// The global service mode. Defaults to `false`
+	// When `true`, tasks will run on every worker node. Conflicts with `replicated`
 	Global pulumi.BoolPtrInput `pulumi:"global"`
 	// The replicated service mode
 	Replicated ServiceModeReplicatedPtrInput `pulumi:"replicated"`
@@ -4676,7 +4676,7 @@ func (o ServiceModeOutput) ToServiceModePtrOutputWithContext(ctx context.Context
 	}).(ServiceModePtrOutput)
 }
 
-// The global service mode. Defaults to `false`
+// When `true`, tasks will run on every worker node. Conflicts with `replicated`
 func (o ServiceModeOutput) Global() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v ServiceMode) *bool { return v.Global }).(pulumi.BoolPtrOutput)
 }
@@ -4710,7 +4710,7 @@ func (o ServiceModePtrOutput) Elem() ServiceModeOutput {
 	}).(ServiceModeOutput)
 }
 
-// The global service mode. Defaults to `false`
+// When `true`, tasks will run on every worker node. Conflicts with `replicated`
 func (o ServiceModePtrOutput) Global() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *ServiceMode) *bool {
 		if v == nil {

--- a/sdk/java/src/main/java/com/pulumi/docker/inputs/ServiceModeArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/inputs/ServiceModeArgs.java
@@ -17,14 +17,14 @@ public final class ServiceModeArgs extends com.pulumi.resources.ResourceArgs {
     public static final ServiceModeArgs Empty = new ServiceModeArgs();
 
     /**
-     * The global service mode. Defaults to `false`
+     * When `true`, tasks will run on every worker node. Conflicts with `replicated`
      * 
      */
     @Import(name="global")
     private @Nullable Output<Boolean> global;
 
     /**
-     * @return The global service mode. Defaults to `false`
+     * @return When `true`, tasks will run on every worker node. Conflicts with `replicated`
      * 
      */
     public Optional<Output<Boolean>> global() {
@@ -72,7 +72,7 @@ public final class ServiceModeArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param global The global service mode. Defaults to `false`
+         * @param global When `true`, tasks will run on every worker node. Conflicts with `replicated`
          * 
          * @return builder
          * 
@@ -83,7 +83,7 @@ public final class ServiceModeArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param global The global service mode. Defaults to `false`
+         * @param global When `true`, tasks will run on every worker node. Conflicts with `replicated`
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/docker/outputs/ServiceMode.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/outputs/ServiceMode.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class ServiceMode {
     /**
-     * @return The global service mode. Defaults to `false`
+     * @return When `true`, tasks will run on every worker node. Conflicts with `replicated`
      * 
      */
     private @Nullable Boolean global;
@@ -25,7 +25,7 @@ public final class ServiceMode {
 
     private ServiceMode() {}
     /**
-     * @return The global service mode. Defaults to `false`
+     * @return When `true`, tasks will run on every worker node. Conflicts with `replicated`
      * 
      */
     public Optional<Boolean> global() {

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -656,7 +656,7 @@ export interface ServiceLabel {
 
 export interface ServiceMode {
     /**
-     * The global service mode. Defaults to `false`
+     * When `true`, tasks will run on every worker node. Conflicts with `replicated`
      */
     global?: pulumi.Input<boolean>;
     /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -592,7 +592,7 @@ export interface ServiceLabel {
 
 export interface ServiceMode {
     /**
-     * The global service mode. Defaults to `false`
+     * When `true`, tasks will run on every worker node. Conflicts with `replicated`
      */
     global?: boolean;
     /**

--- a/sdk/python/pulumi_docker/_inputs.py
+++ b/sdk/python/pulumi_docker/_inputs.py
@@ -2364,7 +2364,7 @@ class ServiceModeArgs:
                  global_: Optional[pulumi.Input[bool]] = None,
                  replicated: Optional[pulumi.Input['ServiceModeReplicatedArgs']] = None):
         """
-        :param pulumi.Input[bool] global_: The global service mode. Defaults to `false`
+        :param pulumi.Input[bool] global_: When `true`, tasks will run on every worker node. Conflicts with `replicated`
         :param pulumi.Input['ServiceModeReplicatedArgs'] replicated: The replicated service mode
         """
         if global_ is not None:
@@ -2376,7 +2376,7 @@ class ServiceModeArgs:
     @pulumi.getter(name="global")
     def global_(self) -> Optional[pulumi.Input[bool]]:
         """
-        The global service mode. Defaults to `false`
+        When `true`, tasks will run on every worker node. Conflicts with `replicated`
         """
         return pulumi.get(self, "global_")
 

--- a/sdk/python/pulumi_docker/outputs.py
+++ b/sdk/python/pulumi_docker/outputs.py
@@ -2113,7 +2113,7 @@ class ServiceMode(dict):
                  global_: Optional[bool] = None,
                  replicated: Optional['outputs.ServiceModeReplicated'] = None):
         """
-        :param bool global_: The global service mode. Defaults to `false`
+        :param bool global_: When `true`, tasks will run on every worker node. Conflicts with `replicated`
         :param 'ServiceModeReplicatedArgs' replicated: The replicated service mode
         """
         if global_ is not None:
@@ -2125,7 +2125,7 @@ class ServiceMode(dict):
     @pulumi.getter(name="global")
     def global_(self) -> Optional[bool]:
         """
-        The global service mode. Defaults to `false`
+        When `true`, tasks will run on every worker node. Conflicts with `replicated`
         """
         return pulumi.get(self, "global_")
 


### PR DESCRIPTION
Removes upstream's Service.global default as a workaround for https://github.com/pulumi/pulumi-terraform-bridge/issues/1095.

The included E2E test reproduced the issue locally and now passes with the fix. We'll see if it passes on CI -- GitHub might need some massaging to get a swarm working.

Fixes #401.