### PR TITLE
Validate fully qualified image names

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -795,9 +795,9 @@ func getRegistryAddrForAuth(serverName, imgName string) (string, error) {
 func getRegistryAddrFromImage(imgName string) (string, error) {
 	named, err := reference.ParseNamed(imgName)
 	if err != nil {
-		msg := fmt.Errorf("error: %s. This provider requires all image names to be fully qualified.\n"+
+		msg := fmt.Errorf("%q: %w.\nThis provider requires all image names to be fully qualified.\n"+
 			"For example, if you are attempting to push to Dockerhub, prefix your image name with `docker.io`:\n\n"+
-			"`docker.io/repository/image:tag`", err)
+			"`docker.io/repository/image:tag`", imgName, err)
 		return "", msg
 	}
 	addr := reference.Domain(named)

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -404,16 +404,15 @@ func TestGetRegistryAddrFromImage(t *testing.T) {
 		expected := ""
 		input := "pulumi-test-registry/unicorns/swiftwind:latest"
 
-		expectedError := fmt.Errorf(
-			"error: repository name must be canonical. This provider requires " +
-				"all image names to be fully qualified.\nFor example, if you are " +
-				"attempting to push to Dockerhub, prefix your image name with " +
-				"`docker.io`:\n\n`docker.io/repository/image:tag`",
-		)
+		expectedError := "\"pulumi-test-registry/unicorns/swiftwind:latest\": repository name must be canonical.\n" +
+			"This provider requires all image names to be fully qualified.\n" +
+			"For example, if you are attempting to push to Dockerhub, prefix your image name with `docker.io`:\n\n" +
+			"`docker.io/repository/image:tag`"
+
 		actual, err := getRegistryAddrFromImage(input)
 		assert.Equal(t, expected, actual)
 		assert.Error(t, err)
-		assert.Equal(t, expectedError, err)
+		assert.ErrorContains(t, err, expectedError)
 	})
 }
 


### PR DESCRIPTION
This validates that `imageName` and `cacheFrom.images` are canonical during `Check`.

Previously, the user would only find out if these were invalid when attempting to run an update.

This also makes the error message slightly more helpful by including the problematic image name.