### PR TITLE
Fix context bug which could hang forever

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -898,7 +898,7 @@ func processLogLine(jm jsonmessage.JSONMessage,
 				info += "failed to parse aux message: " + err.Error()
 			}
 			if err := (&resp).Unmarshal(infoBytes); err != nil {
-				info += "failed to parse aux message: " + err.Error()
+				info += "failed to parse info bytes: " + err.Error()
 			}
 			for _, vertex := range resp.Vertexes {
 				info += fmt.Sprintf("digest: %+v\n", vertex.Digest)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -582,7 +582,7 @@ func (accumulator *contextHashAccumulator) hashPath(
 		if err != nil {
 			return fmt.Errorf("could not copy symlink path %s to hash: %w", filePath, err)
 		}
-	} else {
+	} else if fileMode.IsRegular() {
 		// For regular files, we can hash their content.
 		// TODO: consider only hashing file metadata to improve performance
 		f, err := os.Open(filePath)
@@ -737,7 +737,7 @@ func setConfiguration(configVars map[string]string) map[string]string {
 }
 
 func marshalBuildOnPreview(inputs resource.PropertyMap) bool {
-	//set default if not set
+	// set default if not set
 	if inputs["buildOnPreview"].IsNull() || inputs["buildOnPreview"].ContainsUnknowns() {
 		return false
 	}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/docker/distribution/reference"
@@ -247,8 +248,8 @@ func TestIgnoreIrregularFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a pipe which should be ignored.
-	// err = syscall.Mkfifo(filepath.Join(dir, "pipe"), 0o666)
-	// require.NoError(t, err)
+	err = syscall.Mkfifo(filepath.Join(dir, "pipe"), 0o666)
+	require.NoError(t, err)
 
 	hash, err := hashContext(dir, dockerfile)
 	assert.NoError(t, err)

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -247,14 +247,13 @@ func TestIgnoreIrregularFiles(t *testing.T) {
 	err := os.WriteFile(dockerfile, []byte{}, 0o600)
 	require.NoError(t, err)
 
-	// Create a pipe which should be ignored.
+	// Create a pipe which should be ignored. (We will time out trying to read
+	// it if it's not.)
 	err = syscall.Mkfifo(filepath.Join(dir, "pipe"), 0o666)
 	require.NoError(t, err)
 
-	hash, err := hashContext(dir, dockerfile)
+	_, err = hashContext(dir, dockerfile)
 	assert.NoError(t, err)
-	// Expected hash of just our Dockerfile.
-	assert.Equal(t, "8b1ab751cc04d1d3ada38b648a764e9d10a20ca73981bc46555ef1f955d6964f", hash)
 }
 
 func TestHashUnignoredDirs(t *testing.T) {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -249,8 +249,13 @@ func TestIgnoreIrregularFiles(t *testing.T) {
 
 	// Create a pipe which should be ignored. (We will time out trying to read
 	// it if it's not.)
-	err = syscall.Mkfifo(filepath.Join(dir, "pipe"), 0o666)
+	pipe := filepath.Join(dir, "pipe")
+	err = syscall.Mkfifo(pipe, 0o666)
 	require.NoError(t, err)
+	// Confirm it's irregular.
+	fi, err := os.Stat(pipe)
+	require.NoError(t, err)
+	assert.False(t, fi.Mode().IsRegular())
 
 	_, err = hashContext(dir, dockerfile)
 	assert.NoError(t, err)

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -238,6 +238,24 @@ func TestHashDeepSymlinks(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestIgnoreIrregularFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a Dockerfile
+	dockerfile := filepath.Join(dir, "Dockerfile")
+	err := os.WriteFile(dockerfile, []byte{}, 0o600)
+	require.NoError(t, err)
+
+	// Create a pipe which should be ignored.
+	// err = syscall.Mkfifo(filepath.Join(dir, "pipe"), 0o666)
+	// require.NoError(t, err)
+
+	hash, err := hashContext(dir, dockerfile)
+	assert.NoError(t, err)
+	// Expected hash of just our Dockerfile.
+	assert.Equal(t, "8b1ab751cc04d1d3ada38b648a764e9d10a20ca73981bc46555ef1f955d6964f", hash)
+}
+
 func TestHashUnignoredDirs(t *testing.T) {
 	step1Dir := "./testdata/unignores/basedir"
 	baseResult, err := hashContext(step1Dir, filepath.Join(step1Dir, defaultDockerfile))


### PR DESCRIPTION
We could hang forever if we have irregular file types present, like pipes which never close.

Here we fix the issue by only hashing regular files.

Fixes https://github.com/pulumi/pulumi-docker/issues/614