### PR TITLE
Handle unknown inputs and buildOnPreview

### DIFF
--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -2139,6 +2139,10 @@
                     },
                     "description": "\nAn optional map of named build-time argument variables to set during\nthe Docker build. This flag allows you to pass build-time variables that\ncan be accessed like environment variables inside the RUN\ninstruction."
                 },
+                "buildOnPreview": {
+                    "type": "boolean",
+                    "description": "\nWhen true, attempt to build the image during previews. Outputs are not\npushed to registries, however caches are still populated.\n"
+                },
                 "builder": {
                     "type": "string",
                     "description": "\nBuild with a specific builder instance"
@@ -2219,6 +2223,10 @@
                         "type": "string"
                     },
                     "description": "\nAn optional map of named build-time argument variables to set during\nthe Docker build. This flag allows you to pass build-time variables that\ncan be accessed like environment variables inside the RUN\ninstruction."
+                },
+                "buildOnPreview": {
+                    "type": "boolean",
+                    "description": "\nWhen true, attempt to build the image during previews. Outputs are not\npushed to registries, however caches are still populated.\n"
                 },
                 "builder": {
                     "type": "string",

--- a/provider/internal/client_test.go
+++ b/provider/internal/client_test.go
@@ -26,12 +26,13 @@ func TestAuth(t *testing.T) {
 	}
 	password := os.Getenv("DOCKER_HUB_PASSWORD")
 	host := "pulumi.com" // Fake host -- we don't actually hit it.
+	name := "test-resource"
 
 	t.Cleanup(func() {
 		_ = d.cli.ConfigFile().GetCredentialsStore(host).Erase(host)
 	})
 
-	err = d.Auth(context.Background(), "test-resource", properties.RegistryAuth{
+	err = d.Auth(context.Background(), name, properties.RegistryAuth{
 		Address:  host,
 		Username: user,
 		Password: password,
@@ -39,7 +40,7 @@ func TestAuth(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Perform a second auth; it should be cached.
-	err = d.Auth(context.Background(), "test-resource", properties.RegistryAuth{
+	err = d.Auth(context.Background(), name, properties.RegistryAuth{
 		Address:  host,
 		Username: user,
 		Password: password,

--- a/provider/internal/image.go
+++ b/provider/internal/image.go
@@ -50,17 +50,18 @@ func (i *Image) Annotate(a infer.Annotator) {
 
 // ImageArgs instantiates a new Image.
 type ImageArgs struct {
-	BuildArgs  map[string]string         `pulumi:"buildArgs,optional"`
-	Builder    string                    `pulumi:"builder,optional"`
-	CacheFrom  []string                  `pulumi:"cacheFrom,optional"`
-	CacheTo    []string                  `pulumi:"cacheTo,optional"`
-	Context    string                    `pulumi:"context,optional"`
-	Exports    []string                  `pulumi:"exports,optional"`
-	File       string                    `pulumi:"file,optional"`
-	Platforms  []string                  `pulumi:"platforms,optional"`
-	Pull       bool                      `pulumi:"pull,optional"`
-	Registries []properties.RegistryAuth `pulumi:"registries,optional"`
-	Tags       []string                  `pulumi:"tags"`
+	BuildArgs      map[string]string         `pulumi:"buildArgs,optional"`
+	Builder        string                    `pulumi:"builder,optional"`
+	BuildOnPreview bool                      `pulumi:"buildOnPreview,optional"`
+	CacheFrom      []string                  `pulumi:"cacheFrom,optional"`
+	CacheTo        []string                  `pulumi:"cacheTo,optional"`
+	Context        string                    `pulumi:"context,optional"`
+	Exports        []string                  `pulumi:"exports,optional"`
+	File           string                    `pulumi:"file,optional"`
+	Platforms      []string                  `pulumi:"platforms,optional"`
+	Pull           bool                      `pulumi:"pull,optional"`
+	Registries     []properties.RegistryAuth `pulumi:"registries,optional"`
+	Tags           []string                  `pulumi:"tags"`
 }
 
 // Annotate describes inputs to the Image resource.
@@ -74,6 +75,10 @@ func (ia *ImageArgs) Annotate(a infer.Annotator) {
 	a.Describe(&ia.Builder, dedent.String(`
 		Build with a specific builder instance`,
 	))
+	a.Describe(&ia.BuildOnPreview, dedent.String(`
+		When true, attempt to build the image during previews. Outputs are not
+		pushed to registries, however caches are still populated.
+	`))
 	a.Describe(&ia.CacheFrom, dedent.String(`
 		External cache sources (e.g., "user/app:cache", "type=local,src=path/to/dir")`,
 	))
@@ -134,7 +139,11 @@ func (*Image) Check(
 	if err != nil || len(failures) != 0 {
 		return args, failures, err
 	}
-	if _, berr := args.toBuildOptions(); berr != nil {
+
+	// :(
+	preview := news.ContainsUnknowns()
+
+	if _, berr := args.toBuildOptions(preview); berr != nil {
 		errs := berr.(interface{ Unwrap() []error }).Unwrap()
 		for _, e := range errs {
 			if cf, ok := e.(checkFailure); ok {
@@ -172,62 +181,98 @@ func newCheckFailure(property string, err error) checkFailure {
 	return checkFailure{provider.CheckFailure{Property: property, Reason: err.Error()}}
 }
 
-func (ia *ImageArgs) toBuildOptions() (controllerapi.BuildOptions, error) {
+func (ia *ImageArgs) withoutUnknowns(preview bool) ImageArgs {
+	sk := stringKeeper{preview}
+	filtered := ImageArgs{
+		BuildArgs:      mapKeeper{preview}.keep(ia.BuildArgs),
+		Builder:        ia.Builder,
+		BuildOnPreview: ia.BuildOnPreview,
+		CacheFrom:      filter(sk, ia.CacheFrom...),
+		CacheTo:        filter(sk, ia.CacheTo...),
+		Context:        ia.Context,
+		Exports:        filter(sk, ia.Exports...),
+		File:           ia.File, //
+		Platforms:      filter(sk, ia.Platforms...),
+		Pull:           ia.Pull,
+		Registries:     filter(registryKeeper{preview}, ia.Registries...),
+		Tags:           filter(sk, ia.Tags...),
+	}
+
+	return filtered
+}
+
+func (ia *ImageArgs) buildable() bool {
+	// We can build the given inputs if filtered out unknowns is a no-op.
+	filtered := ia.withoutUnknowns(true)
+	return reflect.DeepEqual(ia, &filtered)
+}
+
+func (ia *ImageArgs) toBuildOptions(preview bool) (controllerapi.BuildOptions, error) {
 	var multierr error
-	exports, err := buildflags.ParseExports(ia.Exports)
-	if err != nil {
-		multierr = errors.Join(multierr, newCheckFailure("exports", err))
-	}
-
-	_, err = platformutil.Parse(ia.Platforms)
-	if err != nil {
-		multierr = errors.Join(multierr, newCheckFailure("platforms", err))
-	}
-
-	cacheFrom, err := buildflags.ParseCacheEntry(ia.CacheFrom)
-	if err != nil {
-		multierr = errors.Join(multierr, newCheckFailure("cacheFrom", err))
-	}
-
-	cacheTo, err := buildflags.ParseCacheEntry(ia.CacheTo)
-	if err != nil {
-		multierr = errors.Join(multierr, newCheckFailure("cacheTo", err))
-	}
-
-	// TODO(https://github.com/pulumi/pulumi-docker/issues/860): Empty build context
-	if ia.Context != "" {
-		if ia.File == "" {
-			ia.File = filepath.Join(ia.Context, "Dockerfile")
-		}
-		if _, err := os.Stat(ia.File); err != nil {
-			multierr = errors.Join(multierr, newCheckFailure("context", err))
-		}
-	}
 
 	if len(ia.Tags) == 0 {
 		multierr = errors.Join(multierr, newCheckFailure("tags", errors.New("at least one tag is required")))
 	}
-	for _, t := range ia.Tags {
-		if t == "" {
-			// TODO(https://github.com/pulumi/pulumi-go-provider/pull/155): This is likely unresolved.
-			continue
+
+	// TODO(https://github.com/pulumi/pulumi-docker/issues/860): Empty build context
+	if ia.Context != "" && !preview {
+		if ia.File == "" {
+			ia.File = filepath.Join(ia.Context, "Dockerfile")
 		}
+		if _, err := os.Stat(ia.File); err != nil {
+			multierr = errors.Join(multierr, newCheckFailure("context", fmt.Errorf("%q: %w", ia.File, err)))
+		}
+	}
+
+	// Discard any unknown inputs if this is a preview -- we don't want them to
+	// cause validation errors.
+	filtered := ia.withoutUnknowns(preview)
+
+	exports, err := buildflags.ParseExports(filtered.Exports)
+	if err != nil {
+		multierr = errors.Join(multierr, newCheckFailure("exports", err))
+	}
+	if preview {
+		// Don't perform registry pushes during previews.
+		for _, e := range exports {
+			if e.Type == "image" && e.Attrs["push"] == "true" {
+				e.Attrs["push"] = "false"
+			}
+		}
+	}
+
+	_, err = platformutil.Parse(filtered.Platforms)
+	if err != nil {
+		multierr = errors.Join(multierr, newCheckFailure("platforms", err))
+	}
+
+	cacheFrom, err := buildflags.ParseCacheEntry(filtered.CacheFrom)
+	if err != nil {
+		multierr = errors.Join(multierr, newCheckFailure("cacheFrom", err))
+	}
+
+	cacheTo, err := buildflags.ParseCacheEntry(filtered.CacheTo)
+	if err != nil {
+		multierr = errors.Join(multierr, newCheckFailure("cacheTo", err))
+	}
+
+	for _, t := range filtered.Tags {
 		if _, err := reference.Parse(t); err != nil {
 			multierr = errors.Join(multierr, newCheckFailure("tags", err))
 		}
 	}
 
 	opts := controllerapi.BuildOptions{
-		BuildArgs:      ia.BuildArgs,
-		Builder:        ia.Builder,
+		BuildArgs:      filtered.BuildArgs,
+		Builder:        filtered.Builder,
 		CacheFrom:      cacheFrom,
 		CacheTo:        cacheTo,
-		ContextPath:    ia.Context,
-		DockerfileName: ia.File,
+		ContextPath:    filtered.Context,
+		DockerfileName: filtered.File,
 		Exports:        exports,
-		Platforms:      ia.Platforms,
-		Pull:           ia.Pull,
-		Tags:           ia.Tags,
+		Platforms:      filtered.Platforms,
+		Pull:           filtered.Pull,
+		Tags:           filtered.Tags,
 	}
 
 	return opts, multierr
@@ -253,7 +298,7 @@ func (i *Image) Update(
 		return state, fmt.Errorf("buildkit is not supported on this host")
 	}
 
-	opts, err := input.toBuildOptions()
+	opts, err := input.toBuildOptions(preview)
 	if err != nil {
 		return state, fmt.Errorf("validating input: %w", err)
 	}
@@ -264,7 +309,11 @@ func (i *Image) Update(
 	}
 	state.ContextHash = hash
 
-	if preview {
+	if preview && !input.BuildOnPreview {
+		return state, nil
+	}
+	if preview && !input.buildable() {
+		ctx.Log(diag.Warning, "Skipping preview build because some inputs are unknown.")
 		return state, nil
 	}
 
@@ -305,7 +354,7 @@ func (*Image) Read(
 	ImageState, // normalized state
 	error,
 ) {
-	opts, err := input.toBuildOptions()
+	opts, err := input.toBuildOptions(false)
 	if err != nil {
 		return name, input, state, err
 	}
@@ -318,6 +367,7 @@ func (*Image) Read(
 		}
 	}
 
+	expectManifest := false
 	manifests := []properties.Manifest{}
 	for _, export := range opts.Exports {
 		switch export.GetType() {
@@ -327,6 +377,7 @@ func (*Image) Read(
 				continue
 			}
 			for _, tag := range input.Tags {
+				expectManifest = true
 				infos, err := cfg.client.Inspect(ctx, name, tag)
 				if err != nil {
 					continue
@@ -357,6 +408,12 @@ func (*Image) Read(
 			// Other export types (e.g. file) are not supported.
 			continue
 		}
+	}
+
+	// If we couldn't find the tags we expected then return an empty ID to
+	// delete the resource.
+	if expectManifest && len(manifests) == 0 {
+		return "", input, state, nil
 	}
 
 	state.Manifests = manifests

--- a/provider/internal/image_test.go
+++ b/provider/internal/image_test.go
@@ -36,6 +36,9 @@ func TestLifecycle(t *testing.T) {
 		return mock.NewMockClient(ctrl)
 	}
 
+	ref, err := reference.ParseNamed("docker.io/pulumibot/myapp")
+	require.NoError(t, err)
+
 	tests := []struct {
 		name string
 
@@ -58,7 +61,12 @@ func TestLifecycle(t *testing.T) {
 						},
 					),
 					c.EXPECT().Inspect(gomock.Any(), "test", "docker.io/blampe/buildkit-e2e").Return(
-						[]manifesttypes.ImageManifest{}, nil,
+						[]manifesttypes.ImageManifest{
+							{
+								Ref:        &manifesttypes.SerializableNamed{Named: ref},
+								Descriptor: v1.Descriptor{Platform: &v1.Platform{}},
+							},
+						}, nil,
 					),
 					c.EXPECT().Inspect(gomock.Any(), "test", "docker.io/blampe/buildkit-e2e:main"),
 					c.EXPECT().Delete(gomock.Any(), "test").Return(
@@ -528,21 +536,150 @@ func TestDiff(t *testing.T) {
 	}
 }
 
-func TestBuildOptionParsing(t *testing.T) {
-	args := ImageArgs{
-		Tags:      []string{"a/bad:tag:format"},
-		Exports:   []string{"badexport,-"},
-		Context:   "./testdata",
-		Platforms: []string{","},
-		CacheFrom: []string{"=badcachefrom"},
-		CacheTo:   []string{"=badcacheto"},
-	}
+func TestBuildOptions(t *testing.T) {
+	t.Run("invalid inputs", func(t *testing.T) {
+		args := ImageArgs{
+			Tags:      []string{"a/bad:tag:format"},
+			Exports:   []string{"badexport,-"},
+			Context:   "./testdata",
+			Platforms: []string{","},
+			CacheFrom: []string{"=badcachefrom"},
+			CacheTo:   []string{"=badcacheto"},
+		}
 
-	_, err := args.toBuildOptions()
-	assert.ErrorContains(t, err, "invalid value badexport")
-	assert.ErrorContains(t, err, "platform specifier component must match")
-	assert.ErrorContains(t, err, "badcachefrom")
-	assert.ErrorContains(t, err, "badcacheto")
-	assert.ErrorContains(t, err, "invalid reference format")
-	assert.ErrorContains(t, err, "testdata/Dockerfile: no such file or directory")
+		_, err := args.toBuildOptions(false)
+		assert.ErrorContains(t, err, "invalid value badexport")
+		assert.ErrorContains(t, err, "platform specifier component must match")
+		assert.ErrorContains(t, err, "badcachefrom")
+		assert.ErrorContains(t, err, "badcacheto")
+		assert.ErrorContains(t, err, "invalid reference format")
+		assert.ErrorContains(t, err, "testdata/Dockerfile: no such file or directory")
+	})
+
+	t.Run("buildOnPreview", func(t *testing.T) {
+		args := ImageArgs{
+			Tags:    []string{"my-tag"},
+			Exports: []string{"type=registry", "type=local", "type=docker"},
+		}
+		actual, err := args.toBuildOptions(true)
+		assert.NoError(t, err)
+		assert.Equal(t, "image", actual.Exports[0].Type)
+		assert.Equal(t, "false", actual.Exports[0].Attrs["push"])
+
+		actual, err = args.toBuildOptions(false)
+		assert.NoError(t, err)
+		assert.Equal(t, "image", actual.Exports[0].Type)
+		assert.Equal(t, "true", actual.Exports[0].Attrs["push"])
+	})
+
+	t.Run("unknowns", func(t *testing.T) {
+		// pulumi-go-provider gives us zero-values when a property is unknown.
+		// We can't distinguish this from user-provided zero-values, but we
+		// should:
+		// - not fail previews due to these zero values,
+		// - not attempt builds with invalid zero values,
+		// - not allow invalid zero values in non-preview operations.
+		unknowns := ImageArgs{
+			BuildArgs: map[string]string{
+				"known": "value",
+				"":      "",
+			},
+			Builder:   "",
+			CacheFrom: []string{"type=gha", ""},
+			CacheTo:   []string{"type=gha", ""},
+			Context:   "",
+			Exports:   []string{"type=gha", ""},
+			File:      "",
+			Platforms: []string{"linux/amd64", ""},
+			Registries: []properties.RegistryAuth{
+				{
+					Address:  "",
+					Password: "",
+					Username: "",
+				},
+			},
+			Tags: []string{"known", ""},
+		}
+
+		_, err := unknowns.toBuildOptions(true)
+		assert.NoError(t, err)
+		assert.False(t, unknowns.buildable())
+
+		_, err = unknowns.toBuildOptions(false)
+		assert.Error(t, err)
+	})
+}
+
+func TestBuildable(t *testing.T) {
+	tests := []struct {
+		name string
+		args ImageArgs
+
+		want bool
+	}{
+		{
+			name: "unknown tags",
+			args: ImageArgs{Tags: []string{""}},
+			want: false,
+		},
+		{
+			name: "unknown exports",
+			args: ImageArgs{
+				Tags:    []string{"known"},
+				Exports: []string{""},
+			},
+			want: false,
+		},
+		{
+			name: "unknown registry",
+			args: ImageArgs{
+				Tags:    []string{"known"},
+				Exports: []string{"type=gha"},
+				Registries: []properties.RegistryAuth{
+					{
+						Address:  "docker.io",
+						Username: "foo",
+						Password: "",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "known tags",
+			args: ImageArgs{
+				Tags: []string{"known"},
+			},
+			want: true,
+		},
+		{
+			name: "known exports",
+			args: ImageArgs{
+				Tags:    []string{"known"},
+				Exports: []string{"type=registry"},
+			},
+			want: true,
+		},
+		{
+			name: "known registry",
+			args: ImageArgs{
+				Tags:    []string{"known"},
+				Exports: []string{"type=gha"},
+				Registries: []properties.RegistryAuth{
+					{
+						Address:  "docker.io",
+						Username: "foo",
+						Password: "bar",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.args.buildable()
+			assert.Equal(t, tt.want, actual)
+		})
+	}
 }

--- a/provider/internal/preview.go
+++ b/provider/internal/preview.go
@@ -1,0 +1,67 @@
+package internal
+
+import (
+	"github.com/pulumi/pulumi-docker/provider/v4/internal/properties"
+)
+
+// keeper decides whether an element should be included for a preview
+// operation, optionally returning a mutated copy of that element.
+type keeper[T any] interface {
+	keep(T) bool
+}
+
+// filter applies a keeper to each element, returning a new slice.
+func filter[T any](k keeper[T], elems ...T) []T {
+	var result []T
+	for _, e := range elems {
+		if !k.keep(e) {
+			continue
+		}
+		result = append(result, e)
+	}
+	return result
+}
+
+// stringKeeper preserves any non-empty string values for preview.
+type stringKeeper struct{ preview bool }
+
+func (k stringKeeper) keep(s string) bool {
+	if !k.preview {
+		return true
+	}
+	return s != ""
+}
+
+// registryKeeper preserves any registries with known values for address and
+// password. This is imprecise and doesn't permit alternative auth strategies
+// like registry tokens, email, etc.
+type registryKeeper struct{ preview bool }
+
+//nolint:unused // False positive due to generics.
+func (k registryKeeper) keep(r properties.RegistryAuth) bool {
+	if !k.preview {
+		return true
+	}
+	return r.Password != "" && r.Address != ""
+}
+
+// mapKeeper preserves map elements with known keys and values.
+type mapKeeper struct{ preview bool }
+
+func (k mapKeeper) keep(m map[string]string) map[string]string {
+	if !k.preview || len(m) == 0 {
+		return m
+	}
+	kk := stringKeeper(k)
+	filtered := make(map[string]string)
+	for key, val := range m {
+		if !kk.keep(key) {
+			continue
+		}
+		if !kk.keep(val) {
+			continue
+		}
+		filtered[key] = val
+	}
+	return filtered
+}

--- a/sdk/dotnet/Buildx/Image.cs
+++ b/sdk/dotnet/Buildx/Image.cs
@@ -27,6 +27,14 @@ namespace Pulumi.Docker.Buildx
 
         /// <summary>
         /// 
+        /// When true, attempt to build the image during previews. Outputs are not
+        /// pushed to registries, however caches are still populated.
+        /// </summary>
+        [Output("buildOnPreview")]
+        public Output<bool?> BuildOnPreview { get; private set; } = null!;
+
+        /// <summary>
+        /// 
         /// Build with a specific builder instance
         /// </summary>
         [Output("builder")]
@@ -165,6 +173,14 @@ namespace Pulumi.Docker.Buildx
             get => _buildArgs ?? (_buildArgs = new InputMap<string>());
             set => _buildArgs = value;
         }
+
+        /// <summary>
+        /// 
+        /// When true, attempt to build the image during previews. Outputs are not
+        /// pushed to registries, however caches are still populated.
+        /// </summary>
+        [Input("buildOnPreview")]
+        public Input<bool>? BuildOnPreview { get; set; }
 
         /// <summary>
         /// 

--- a/sdk/go/docker/buildx/image.go
+++ b/sdk/go/docker/buildx/image.go
@@ -21,6 +21,9 @@ type Image struct {
 	// can be accessed like environment variables inside the RUN
 	// instruction.
 	BuildArgs pulumi.StringMapOutput `pulumi:"buildArgs"`
+	// When true, attempt to build the image during previews. Outputs are not
+	// pushed to registries, however caches are still populated.
+	BuildOnPreview pulumi.BoolPtrOutput `pulumi:"buildOnPreview"`
 	// Build with a specific builder instance
 	Builder pulumi.StringPtrOutput `pulumi:"builder"`
 	// External cache sources (e.g., "user/app:cache", "type=local,src=path/to/dir")
@@ -100,6 +103,9 @@ type imageArgs struct {
 	// can be accessed like environment variables inside the RUN
 	// instruction.
 	BuildArgs map[string]string `pulumi:"buildArgs"`
+	// When true, attempt to build the image during previews. Outputs are not
+	// pushed to registries, however caches are still populated.
+	BuildOnPreview *bool `pulumi:"buildOnPreview"`
 	// Build with a specific builder instance
 	Builder *string `pulumi:"builder"`
 	// External cache sources (e.g., "user/app:cache", "type=local,src=path/to/dir")
@@ -133,6 +139,9 @@ type ImageArgs struct {
 	// can be accessed like environment variables inside the RUN
 	// instruction.
 	BuildArgs pulumi.StringMapInput
+	// When true, attempt to build the image during previews. Outputs are not
+	// pushed to registries, however caches are still populated.
+	BuildOnPreview pulumi.BoolPtrInput
 	// Build with a specific builder instance
 	Builder pulumi.StringPtrInput
 	// External cache sources (e.g., "user/app:cache", "type=local,src=path/to/dir")
@@ -252,6 +261,12 @@ func (o ImageOutput) ToImageOutputWithContext(ctx context.Context) ImageOutput {
 // instruction.
 func (o ImageOutput) BuildArgs() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *Image) pulumi.StringMapOutput { return v.BuildArgs }).(pulumi.StringMapOutput)
+}
+
+// When true, attempt to build the image during previews. Outputs are not
+// pushed to registries, however caches are still populated.
+func (o ImageOutput) BuildOnPreview() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Image) pulumi.BoolPtrOutput { return v.BuildOnPreview }).(pulumi.BoolPtrOutput)
 }
 
 // Build with a specific builder instance

--- a/sdk/java/src/main/java/com/pulumi/docker/buildx/Image.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/buildx/Image.java
@@ -46,6 +46,23 @@ public class Image extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.buildArgs);
     }
     /**
+     * When true, attempt to build the image during previews. Outputs are not
+     * pushed to registries, however caches are still populated.
+     * 
+     */
+    @Export(name="buildOnPreview", refs={Boolean.class}, tree="[0]")
+    private Output</* @Nullable */ Boolean> buildOnPreview;
+
+    /**
+     * @return
+     * When true, attempt to build the image during previews. Outputs are not
+     * pushed to registries, however caches are still populated.
+     * 
+     */
+    public Output<Optional<Boolean>> buildOnPreview() {
+        return Codegen.optional(this.buildOnPreview);
+    }
+    /**
      * Build with a specific builder instance
      * 
      */

--- a/sdk/java/src/main/java/com/pulumi/docker/buildx/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/buildx/ImageArgs.java
@@ -44,6 +44,24 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * When true, attempt to build the image during previews. Outputs are not
+     * pushed to registries, however caches are still populated.
+     * 
+     */
+    @Import(name="buildOnPreview")
+    private @Nullable Output<Boolean> buildOnPreview;
+
+    /**
+     * @return
+     * When true, attempt to build the image during previews. Outputs are not
+     * pushed to registries, however caches are still populated.
+     * 
+     */
+    public Optional<Output<Boolean>> buildOnPreview() {
+        return Optional.ofNullable(this.buildOnPreview);
+    }
+
+    /**
      * Build with a specific builder instance
      * 
      */
@@ -215,6 +233,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
 
     private ImageArgs(ImageArgs $) {
         this.buildArgs = $.buildArgs;
+        this.buildOnPreview = $.buildOnPreview;
         this.builder = $.builder;
         this.cacheFrom = $.cacheFrom;
         this.cacheTo = $.cacheTo;
@@ -272,6 +291,31 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder buildArgs(Map<String,String> buildArgs) {
             return buildArgs(Output.of(buildArgs));
+        }
+
+        /**
+         * @param buildOnPreview
+         * When true, attempt to build the image during previews. Outputs are not
+         * pushed to registries, however caches are still populated.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder buildOnPreview(@Nullable Output<Boolean> buildOnPreview) {
+            $.buildOnPreview = buildOnPreview;
+            return this;
+        }
+
+        /**
+         * @param buildOnPreview
+         * When true, attempt to build the image during previews. Outputs are not
+         * pushed to registries, however caches are still populated.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder buildOnPreview(Boolean buildOnPreview) {
+            return buildOnPreview(Output.of(buildOnPreview));
         }
 
         /**

--- a/sdk/nodejs/buildx/image.ts
+++ b/sdk/nodejs/buildx/image.ts
@@ -47,6 +47,12 @@ export class Image extends pulumi.CustomResource {
     public readonly buildArgs!: pulumi.Output<{[key: string]: string} | undefined>;
     /**
      *
+     * When true, attempt to build the image during previews. Outputs are not
+     * pushed to registries, however caches are still populated.
+     */
+    public readonly buildOnPreview!: pulumi.Output<boolean | undefined>;
+    /**
+     *
      * Build with a specific builder instance
      */
     public readonly builder!: pulumi.Output<string | undefined>;
@@ -117,6 +123,7 @@ export class Image extends pulumi.CustomResource {
                 throw new Error("Missing required property 'tags'");
             }
             resourceInputs["buildArgs"] = args ? args.buildArgs : undefined;
+            resourceInputs["buildOnPreview"] = args ? args.buildOnPreview : undefined;
             resourceInputs["builder"] = args ? args.builder : undefined;
             resourceInputs["cacheFrom"] = args ? args.cacheFrom : undefined;
             resourceInputs["cacheTo"] = args ? args.cacheTo : undefined;
@@ -131,6 +138,7 @@ export class Image extends pulumi.CustomResource {
             resourceInputs["manifests"] = undefined /*out*/;
         } else {
             resourceInputs["buildArgs"] = undefined /*out*/;
+            resourceInputs["buildOnPreview"] = undefined /*out*/;
             resourceInputs["builder"] = undefined /*out*/;
             resourceInputs["cacheFrom"] = undefined /*out*/;
             resourceInputs["cacheTo"] = undefined /*out*/;
@@ -161,6 +169,12 @@ export interface ImageArgs {
      * instruction.
      */
     buildArgs?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    /**
+     *
+     * When true, attempt to build the image during previews. Outputs are not
+     * pushed to registries, however caches are still populated.
+     */
+    buildOnPreview?: pulumi.Input<boolean>;
     /**
      *
      * Build with a specific builder instance

--- a/sdk/python/pulumi_docker/buildx/image.py
+++ b/sdk/python/pulumi_docker/buildx/image.py
@@ -18,6 +18,7 @@ class ImageArgs:
     def __init__(__self__, *,
                  tags: pulumi.Input[Sequence[pulumi.Input[str]]],
                  build_args: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 build_on_preview: Optional[pulumi.Input[bool]] = None,
                  builder: Optional[pulumi.Input[str]] = None,
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  cache_to: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -37,6 +38,9 @@ class ImageArgs:
                the Docker build. This flag allows you to pass build-time variables that
                can be accessed like environment variables inside the RUN
                instruction.
+        :param pulumi.Input[bool] build_on_preview: 
+               When true, attempt to build the image during previews. Outputs are not
+               pushed to registries, however caches are still populated.
         :param pulumi.Input[str] builder: 
                Build with a specific builder instance
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_from: 
@@ -62,6 +66,8 @@ class ImageArgs:
         pulumi.set(__self__, "tags", tags)
         if build_args is not None:
             pulumi.set(__self__, "build_args", build_args)
+        if build_on_preview is not None:
+            pulumi.set(__self__, "build_on_preview", build_on_preview)
         if builder is not None:
             pulumi.set(__self__, "builder", builder)
         if cache_from is not None:
@@ -112,6 +118,20 @@ class ImageArgs:
     @build_args.setter
     def build_args(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "build_args", value)
+
+    @property
+    @pulumi.getter(name="buildOnPreview")
+    def build_on_preview(self) -> Optional[pulumi.Input[bool]]:
+        """
+
+        When true, attempt to build the image during previews. Outputs are not
+        pushed to registries, however caches are still populated.
+        """
+        return pulumi.get(self, "build_on_preview")
+
+    @build_on_preview.setter
+    def build_on_preview(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "build_on_preview", value)
 
     @property
     @pulumi.getter
@@ -240,6 +260,7 @@ class Image(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  build_args: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 build_on_preview: Optional[pulumi.Input[bool]] = None,
                  builder: Optional[pulumi.Input[str]] = None,
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  cache_to: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -261,6 +282,9 @@ class Image(pulumi.CustomResource):
                the Docker build. This flag allows you to pass build-time variables that
                can be accessed like environment variables inside the RUN
                instruction.
+        :param pulumi.Input[bool] build_on_preview: 
+               When true, attempt to build the image during previews. Outputs are not
+               pushed to registries, however caches are still populated.
         :param pulumi.Input[str] builder: 
                Build with a specific builder instance
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_from: 
@@ -311,6 +335,7 @@ class Image(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  build_args: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 build_on_preview: Optional[pulumi.Input[bool]] = None,
                  builder: Optional[pulumi.Input[str]] = None,
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  cache_to: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -331,6 +356,7 @@ class Image(pulumi.CustomResource):
             __props__ = ImageArgs.__new__(ImageArgs)
 
             __props__.__dict__["build_args"] = build_args
+            __props__.__dict__["build_on_preview"] = build_on_preview
             __props__.__dict__["builder"] = builder
             __props__.__dict__["cache_from"] = cache_from
             __props__.__dict__["cache_to"] = cache_to
@@ -370,6 +396,7 @@ class Image(pulumi.CustomResource):
         __props__ = ImageArgs.__new__(ImageArgs)
 
         __props__.__dict__["build_args"] = None
+        __props__.__dict__["build_on_preview"] = None
         __props__.__dict__["builder"] = None
         __props__.__dict__["cache_from"] = None
         __props__.__dict__["cache_to"] = None
@@ -395,6 +422,16 @@ class Image(pulumi.CustomResource):
         instruction.
         """
         return pulumi.get(self, "build_args")
+
+    @property
+    @pulumi.getter(name="buildOnPreview")
+    def build_on_preview(self) -> pulumi.Output[Optional[bool]]:
+        """
+
+        When true, attempt to build the image during previews. Outputs are not
+        pushed to registries, however caches are still populated.
+        """
+        return pulumi.get(self, "build_on_preview")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
This PR improves our handling of unknown inputs by working around some of our
API limitations:

* `Check` always receives property maps but not whether the operation is a
  preview. To work around this, we use the presence of unknowns to toggle
  preview-only behavior.
* `Update` receives a `preview` boolean, but its state/args are simple structs
  whose fields are zero values when unknown. To handle this, during preview
  operations we omit zero-value fields when validating and building images.

Taken together these workarounds behave _reasonably_ well, however there are
still edge cases -- for example user-provided zero values won't return
validation errors. Additionally from a DX standpoint there's definitely room
for a more ergonic (and less error-prone) API here.

Related https://github.com/pulumi/pulumi-go-provider/pull/155
Fixes https://github.com/pulumi/pulumi-docker/issues/969
