### PR TITLE
Multi-platform caching for buildx

### DIFF
--- a/examples/aws-container-registry/ts/index.ts
+++ b/examples/aws-container-registry/ts/index.ts
@@ -51,6 +51,12 @@ const buildxImage = new docker.buildx.Image("buildx", {
   exports: ["type=registry"],
   file: "app/Dockerfile",
   platforms: ["linux/arm64", "linux/amd64"],
+  cacheTo: [
+    pulumi.interpolate`type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${repo.repositoryUrl}:cache`,
+  ],
+  cacheFrom: [
+    pulumi.interpolate`type=registry,ref=${repo.repositoryUrl}:cache`,
+  ],
   context: "app",
   registries: [
     {

--- a/examples/docker-container-registry/ts/index.ts
+++ b/examples/docker-container-registry/ts/index.ts
@@ -33,6 +33,8 @@ const buildxImage = new docker.buildx.Image("my-buildx-image", {
   tags: [`${imageName}:buildx`],
   exports: ["type=registry"],
   platforms: ["linux/arm64", "linux/amd64"],
+  cacheFrom: ["type=gha", `type=registry,ref=docker.io/${imageName}`],
+  cacheTo: ["type=gha", `type=registry,ref=docker.io/${imageName},mode=max`],
   context: "app",
   file: "app/Dockerfile",
   registries: [

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,6 +3,7 @@ module github.com/pulumi/pulumi-docker/examples
 go 1.21
 
 require (
+	github.com/aws/aws-sdk-go v1.49.0
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/pulumi/pulumi/pkg/v3 v3.107.0
 	github.com/stretchr/testify v1.8.4
@@ -34,7 +35,6 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
-	github.com/aws/aws-sdk-go v1.49.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.24.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.26.1 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.12 // indirect
@@ -133,7 +133,7 @@ require (
 	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.0.2 // indirect
+	github.com/opencontainers/image-spec v1.1.0-rc3 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pgavlin/fx v0.1.6 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1693,8 +1693,9 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.2-0.20211117181255-693428a734f5/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.1.0-rc3 h1:fzg1mXZFj8YdPeNkRXMg+zb88BFV0Ys52cJydRwBkb8=
+github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=

--- a/examples/test-buildx/caching/ts/Dockerfile
+++ b/examples/test-buildx/caching/ts/Dockerfile
@@ -1,0 +1,7 @@
+FROM --platform=$BUILDPLATFORM golang:1.21.6-alpine3.18 as initial
+ARG SLEEP_SECONDS
+RUN sleep ${SLEEP_SECONDS} && echo ${SLEEP_SECONDS} > output
+
+FROM alpine:3.18 as final
+COPY --from=initial /go/output output
+RUN cat output

--- a/examples/test-buildx/caching/ts/Pulumi.yaml
+++ b/examples/test-buildx/caching/ts/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: test-buildx-caching
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/examples/test-buildx/caching/ts/index.ts
+++ b/examples/test-buildx/caching/ts/index.ts
@@ -1,0 +1,44 @@
+import * as docker from "@pulumi/docker";
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config();
+
+const start = new Date().getTime();
+
+// docker buildx build \
+//  -f Dockerfile \
+//  --cache-to type=local,dest=tmp,mode=max,oci-mediatypes=true \
+//  --cache-from type=local,src=tmp \
+//  --build-arg SLEEP-MS=$SLEEP_MS \
+//  -t not-pushed \
+//  -f Dockerfile \
+//  --platform linux/arm64 \
+//  --platform linux/amd64 \
+//  .
+const img = new docker.buildx.Image(`buildx-${config.require("name")}`, {
+  tags: ["not-pushed"],
+  file: "Dockerfile",
+  context: ".",
+  platforms: ["linux/arm64", "linux/amd64"],
+  buildArgs: {
+    SLEEP_SECONDS: config.require("SLEEP_SECONDS"),
+  },
+  cacheTo: [config.require("cacheTo")],
+  cacheFrom: [config.require("cacheFrom")],
+  // Set registry auth if it was provided.
+  registries: config.getSecret("username").apply((a) =>
+    a
+      ? [
+          {
+            address: config.getSecret("address"),
+            username: config.getSecret("username"),
+            password: config.getSecret("password"),
+          },
+        ]
+      : undefined
+  ),
+});
+
+export const durationSeconds = img.manifests.apply(
+  (_) => (new Date().getTime() - start) / 1000.0
+);

--- a/examples/test-buildx/caching/ts/package.json
+++ b/examples/test-buildx/caching/ts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-buildx-caching",
+  "devDependencies": {
+    "@types/node": "^20.0.0"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0"
+  }
+}

--- a/provider/internal/image_test.go
+++ b/provider/internal/image_test.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/docker/buildx/driver/docker-container"
 
 	controllerapi "github.com/docker/buildx/controller/pb"
+	"github.com/docker/buildx/util/buildflags"
 	manifesttypes "github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types/image"
@@ -680,6 +681,136 @@ func TestBuildable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			actual := tt.args.buildable()
 			assert.Equal(t, tt.want, actual)
+		})
+	}
+}
+
+func TestToBuilds(t *testing.T) {
+	t.Run("single-platform caching", func(t *testing.T) {
+		ia := ImageArgs{
+			Tags:      []string{"foo", "bar"},
+			Platforms: []string{"linux/amd64"},
+			CacheTo: []string{
+				"type=gha,mode=max",
+				"type=registry,ref=docker.io/foo/bar",
+				"type=registry,ref=docker.io/foo/bar:baz",
+			},
+			CacheFrom: []string{
+				"type=s3,name=bar",
+				"type=registry,ref=docker.io/foo/bar",
+				"type=registry,ref=docker.io/foo/bar:baz",
+			},
+		}
+		builds, err := ia.toBuilds(nil, false)
+		assert.NoError(t, err)
+		assert.Len(t, builds, 1)
+	})
+
+	t.Run("multi-platform caching", func(t *testing.T) {
+		t.Setenv("ACTIONS_CACHE_URL", "fake-url")
+		t.Setenv("ACTIONS_RUNTIME_TOKEN", "fake-token")
+
+		ia := ImageArgs{
+			Tags:      []string{"foo", "bar"},
+			Platforms: []string{"linux/amd64", "linux/arm64"},
+			CacheTo: []string{
+				"type=gha,mode=max",
+				"type=registry,ref=docker.io/foo/bar",
+				"type=registry,ref=docker.io/foo/bar:baz",
+			},
+			CacheFrom: []string{
+				"type=s3,name=bar",
+				"type=registry,ref=docker.io/foo/bar",
+				"type=registry,ref=docker.io/foo/bar:baz",
+			},
+		}
+
+		builds, err := ia.toBuilds(nil, false)
+		assert.NoError(t, err)
+
+		assert.Len(t, builds, 3)
+
+		// Build 1
+		assert.Nil(t, builds[0].CacheTo)
+		assert.Len(t, builds[0].CacheFrom, len(ia.CacheFrom)*(1+len(ia.Platforms)))
+		assert.Len(t, builds[0].Platforms, len(ia.Platforms))
+
+		// Build 2
+		assert.Len(t, builds[1].Platforms, 1)
+		assert.Equal(t, "linux/amd64", builds[1].Platforms[0])
+		assert.Len(t, builds[1].Exports, 1)
+		assert.Equal(t, "cacheonly", builds[1].Exports[0].Type)
+		assert.Len(t, builds[1].CacheTo, len(ia.CacheTo))
+
+		// Build 3
+		assert.Len(t, builds[2].Platforms, 1)
+		assert.Equal(t, "linux/arm64", builds[2].Platforms[0])
+		assert.Len(t, builds[2].Exports, 1)
+		assert.Equal(t, "cacheonly", builds[2].Exports[0].Type)
+		assert.Len(t, builds[2].CacheTo, len(ia.CacheTo))
+	})
+}
+
+func TestToCaches(t *testing.T) {
+	tests := []struct {
+		name      string
+		platforms []string
+		caches    []string
+
+		want []string
+	}{
+		{
+			name:      "single-platform",
+			platforms: []string{"linux/amd64"},
+			caches: []string{
+				"type=registry,ref=docker.io/foo/bar:baz",
+				"type=inline",
+				"type=local,src=/foo",
+				"type=s3",
+			},
+			want: []string{
+				"type=registry,ref=docker.io/foo/bar:baz",
+				"type=inline",
+				"type=local,src=/foo",
+				"type=s3",
+			},
+		},
+		{
+			name:      "multi-platform",
+			platforms: []string{"linux/amd64", "linux/arm64", "linux/amd64"},
+			caches: []string{
+				"type=registry,ref=docker.io/foo/bar",
+				"type=registry,ref=docker.io/foo/bar:baz",
+				"type=inline",
+				"type=local,src=/foo",
+				"type=s3",
+				"type=gha",
+			},
+			want: []string{
+				"type=registry,ref=docker.io/foo/bar:linux-amd64",
+				"type=registry,ref=docker.io/foo/bar:linux-arm64",
+				"type=registry,ref=docker.io/foo/bar:baz-linux-amd64",
+				"type=registry,ref=docker.io/foo/bar:baz-linux-arm64",
+				"type=inline",
+				"type=local,src=/foo-linux-amd64",
+				"type=local,src=/foo-linux-arm64",
+				"type=s3,name=linux-amd64",
+				"type=s3,name=linux-arm64",
+				"type=gha,scope=linux-amd64",
+				"type=gha,scope=linux-arm64",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caches, err := buildflags.ParseCacheEntry(tt.caches)
+			require.NoError(t, err)
+			want, err := buildflags.ParseCacheEntry(tt.want)
+			require.NoError(t, err)
+
+			actual := cachesFor(nil, caches, tt.platforms...)
+			assert.Equal(t, want, actual)
 		})
 	}
 }


### PR DESCRIPTION
buildkit doesn't support multi-platform caches, so `--cache-to` with
`--platforms` can race such that only one platform is cached and subsequent
operations must re-build remaining platforms.

The recommended workaround is to perform a build without `--cache-to`, and then
perform P additional builds for each platform to push a platform-specific
cache.

We have two choices:
1. We can detect this situation and refuse to build, with an error providing
   guidance for the user. An x86/ARM image would need 3 `buildx.Image` to
   propertly cache itself. If/when Docker resolves
   https://github.com/docker/buildx/issues/1044, users would need to clean up
   their extraneous resources in order to leverage upstream's behavior. In most
   cases this cleanup will simply never happen (assuming most users don't
   closely follow Docker implementation details.)
2. We can detect this situation and automatically apply the workaround for the
   user. Only one `buildx.Image` is needed. If/when Docker resolves
   https://github.com/docker/buildx/issues/1044 we can instead rely on upstream
   behavior without any action needed from the user.

The workaround (option 1) is certainly possible with Pulumi today, however it's
awkward and I would rather not force this complexity on users who expect this
to Just Work™.

So this PR implements the second option. We detect this situation and munge the
build options such that we perform an initial build without `--cache-to`, and
then we push platform-specific caches. In the registry case we jump through
some hoops to prevent these derived cache keys from getting exposed as tag
names.

