### PR TITLE
Fix SSH incompatibility with v25

### DIFF
--- a/examples/test-ssh-conn/ts/Dockerfile
+++ b/examples/test-ssh-conn/ts/Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch

--- a/examples/test-ssh-conn/ts/index.ts
+++ b/examples/test-ssh-conn/ts/index.ts
@@ -32,7 +32,14 @@ const provider = new docker.Provider("docker-provider", {
     ],
 });
 
-const remoteImage = new docker.RemoteImage("image", {
+const image = new docker.Image("image", {
+    imageName: "docker.io/pulumibot/foo",
+    skipPush: true,
+  },
+  { provider }
+);
+
+const remoteImage = new docker.RemoteImage("remote-image", {
     name: "nginx"
 }, { provider });
 

--- a/provider/image.go
+++ b/provider/image.go
@@ -91,7 +91,6 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 	props *structpb.Struct,
 	isPreview bool,
 ) (string, *structpb.Struct, error) {
-
 	inputs, err := plugin.UnmarshalProperties(props, plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
 	if err != nil {
 		return "", nil, err
@@ -1108,8 +1107,9 @@ func configureDockerClientInner(configs map[string]string, host string) (*client
 				clientOpts = append(clientOpts,
 					client.FromEnv,
 					client.WithAPIVersionNegotiation(),
+					client.WithHost(helper.Host),
 					client.WithDialContext(helper.Dialer),
-					client.WithHost(helper.Host))
+				)
 			} else {
 				// if no helper is registered for the scheme, we return a non-SSH client using the supplied host.
 				clientOpts = append(clientOpts,


### PR DESCRIPTION
The v25 upgrade made us sensitive to the ordering of our client options.

In particular if a host was specified last it would take precedence over the SSH dialer. This behavior was accounted for in the [upstream patch](https://github.com/pulumi/pulumi-docker/blob/f866a5a4ae5e67edee4a92b8930a6ac7ee1d305a/patches/0006-upgrade-docker-sdk.patch#L288-L289) but not in our own host resolution logic.

The PR adds a failing e2e test and a corresponding fix to our client options.
