### PR TITLE
Mark some computed properties as optional

### DIFF
--- a/provider/cmd/pulumi-resource-docker/schema.json
+++ b/provider/cmd/pulumi-resource-docker/schema.json
@@ -2406,11 +2406,9 @@
             "required": [
                 "bridge",
                 "command",
-                "containerLogs",
                 "entrypoints",
                 "envs",
                 "exitCode",
-                "healthcheck",
                 "hostname",
                 "image",
                 "init",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -105,6 +105,12 @@ func Provider() tfbridge.ProviderInfo {
 					"networks_advanced": {
 						Name: "networksAdvanced",
 					},
+					"container_logs": {
+						MarkAsOptional: tfbridge.True(),
+					},
+					"healthcheck": {
+						MarkAsOptional: tfbridge.True(),
+					},
 				},
 			},
 			"docker_image": {

--- a/sdk/dotnet/Container.cs
+++ b/sdk/dotnet/Container.cs
@@ -119,7 +119,7 @@ namespace Pulumi.Docker
         /// The logs of the container if its execution is done (`attach` must be disabled).
         /// </summary>
         [Output("containerLogs")]
-        public Output<string> ContainerLogs { get; private set; } = null!;
+        public Output<string?> ContainerLogs { get; private set; } = null!;
 
         /// <summary>
         /// The total number of milliseconds to wait for the container to reach status 'running'
@@ -209,7 +209,7 @@ namespace Pulumi.Docker
         /// A test to perform to check that the container is healthy
         /// </summary>
         [Output("healthcheck")]
-        public Output<Outputs.ContainerHealthcheck> Healthcheck { get; private set; } = null!;
+        public Output<Outputs.ContainerHealthcheck?> Healthcheck { get; private set; } = null!;
 
         /// <summary>
         /// Hostname of the container.

--- a/sdk/go/docker/container.go
+++ b/sdk/go/docker/container.go
@@ -106,7 +106,7 @@ type Container struct {
 	// The command to use to start the container. For example, to run `/usr/bin/myprogram -f baz.conf` set the command to be `["/usr/bin/myprogram","-f","baz.con"]`.
 	Command pulumi.StringArrayOutput `pulumi:"command"`
 	// The logs of the container if its execution is done (`attach` must be disabled).
-	ContainerLogs pulumi.StringOutput `pulumi:"containerLogs"`
+	ContainerLogs pulumi.StringPtrOutput `pulumi:"containerLogs"`
 	// The total number of milliseconds to wait for the container to reach status 'running'
 	ContainerReadRefreshTimeoutMilliseconds pulumi.IntPtrOutput `pulumi:"containerReadRefreshTimeoutMilliseconds"`
 	// A comma-separated list or hyphen-separated range of CPUs a container can use, e.g. `0-1`.
@@ -136,7 +136,7 @@ type Container struct {
 	// Additional groups for the container user
 	GroupAdds pulumi.StringArrayOutput `pulumi:"groupAdds"`
 	// A test to perform to check that the container is healthy
-	Healthcheck ContainerHealthcheckOutput `pulumi:"healthcheck"`
+	Healthcheck ContainerHealthcheckPtrOutput `pulumi:"healthcheck"`
 	// Hostname of the container.
 	Hostname pulumi.StringOutput `pulumi:"hostname"`
 	// Hostname to add
@@ -908,8 +908,8 @@ func (o ContainerOutput) Command() pulumi.StringArrayOutput {
 }
 
 // The logs of the container if its execution is done (`attach` must be disabled).
-func (o ContainerOutput) ContainerLogs() pulumi.StringOutput {
-	return o.ApplyT(func(v *Container) pulumi.StringOutput { return v.ContainerLogs }).(pulumi.StringOutput)
+func (o ContainerOutput) ContainerLogs() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Container) pulumi.StringPtrOutput { return v.ContainerLogs }).(pulumi.StringPtrOutput)
 }
 
 // The total number of milliseconds to wait for the container to reach status 'running'
@@ -983,8 +983,8 @@ func (o ContainerOutput) GroupAdds() pulumi.StringArrayOutput {
 }
 
 // A test to perform to check that the container is healthy
-func (o ContainerOutput) Healthcheck() ContainerHealthcheckOutput {
-	return o.ApplyT(func(v *Container) ContainerHealthcheckOutput { return v.Healthcheck }).(ContainerHealthcheckOutput)
+func (o ContainerOutput) Healthcheck() ContainerHealthcheckPtrOutput {
+	return o.ApplyT(func(v *Container) ContainerHealthcheckPtrOutput { return v.Healthcheck }).(ContainerHealthcheckPtrOutput)
 }
 
 // Hostname of the container.

--- a/sdk/java/src/main/java/com/pulumi/docker/Container.java
+++ b/sdk/java/src/main/java/com/pulumi/docker/Container.java
@@ -196,14 +196,14 @@ public class Container extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="containerLogs", refs={String.class}, tree="[0]")
-    private Output<String> containerLogs;
+    private Output</* @Nullable */ String> containerLogs;
 
     /**
      * @return The logs of the container if its execution is done (`attach` must be disabled).
      * 
      */
-    public Output<String> containerLogs() {
-        return this.containerLogs;
+    public Output<Optional<String>> containerLogs() {
+        return Codegen.optional(this.containerLogs);
     }
     /**
      * The total number of milliseconds to wait for the container to reach status &#39;running&#39;
@@ -406,14 +406,14 @@ public class Container extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="healthcheck", refs={ContainerHealthcheck.class}, tree="[0]")
-    private Output<ContainerHealthcheck> healthcheck;
+    private Output</* @Nullable */ ContainerHealthcheck> healthcheck;
 
     /**
      * @return A test to perform to check that the container is healthy
      * 
      */
-    public Output<ContainerHealthcheck> healthcheck() {
-        return this.healthcheck;
+    public Output<Optional<ContainerHealthcheck>> healthcheck() {
+        return Codegen.optional(this.healthcheck);
     }
     /**
      * Hostname of the container.

--- a/sdk/nodejs/container.ts
+++ b/sdk/nodejs/container.ts
@@ -118,7 +118,7 @@ export class Container extends pulumi.CustomResource {
     /**
      * The logs of the container if its execution is done (`attach` must be disabled).
      */
-    public /*out*/ readonly containerLogs!: pulumi.Output<string>;
+    public /*out*/ readonly containerLogs!: pulumi.Output<string | undefined>;
     /**
      * The total number of milliseconds to wait for the container to reach status 'running'
      */
@@ -178,7 +178,7 @@ export class Container extends pulumi.CustomResource {
     /**
      * A test to perform to check that the container is healthy
      */
-    public readonly healthcheck!: pulumi.Output<outputs.ContainerHealthcheck>;
+    public readonly healthcheck!: pulumi.Output<outputs.ContainerHealthcheck | undefined>;
     /**
      * Hostname of the container.
      */

--- a/sdk/python/pulumi_docker/container.py
+++ b/sdk/python/pulumi_docker/container.py
@@ -2759,7 +2759,7 @@ class Container(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="containerLogs")
-    def container_logs(self) -> pulumi.Output[str]:
+    def container_logs(self) -> pulumi.Output[Optional[str]]:
         """
         The logs of the container if its execution is done (`attach` must be disabled).
         """
@@ -2879,7 +2879,7 @@ class Container(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def healthcheck(self) -> pulumi.Output['outputs.ContainerHealthcheck']:
+    def healthcheck(self) -> pulumi.Output[Optional['outputs.ContainerHealthcheck']]:
         """
         A test to perform to check that the container is healthy
         """


### PR DESCRIPTION
Refs https://github.com/pulumi/pulumi-terraform-bridge/issues/1239#issuecomment-1814792814

This is a breaking change to the SDK, so I'm conflicted on whether this is a reasonable fix. It would be helpful to hear from users impacted by this behavior. 

The only situation where the breakage could is justified IMO is if the resource is essentially unusable without this fix. If some users are already using the resource without issue, then I think we'll need to find a different way to handle this without breaking them.

Fixes https://github.com/pulumi/pulumi-docker/issues/1052