### PR TITLE
Prototype: Add the ability to ignore changes to volatile provider configuration (WIP)

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -239,6 +239,23 @@ func TestLocalRepoDigestNode(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestRegistryTokenAuth(t *testing.T) {
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		t.Skipf("Skipping test due to missing AWS_REGION environment variable")
+	}
+	test := getJsOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "registry-token-auth"),
+			Config: map[string]string{
+				"aws:region": region,
+			},
+			ExtraRuntimeValidation: assertHasRepoDigest,
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func getJsOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions()
 	baseJs := base.With(integration.ProgramTestOptions{

--- a/examples/registry-token-auth/.gitignore
+++ b/examples/registry-token-auth/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/examples/registry-token-auth/Pulumi.yaml
+++ b/examples/registry-token-auth/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: registry-token-auth
+runtime: nodejs
+description: A minimal AWS TypeScript Pulumi program

--- a/examples/registry-token-auth/app/Dockerfile
+++ b/examples/registry-token-auth/app/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx
+RUN echo "<h1>Hi from Pulumi!</h1>" > \
+    /usr/share/nginx/html/index.html

--- a/examples/registry-token-auth/index.ts
+++ b/examples/registry-token-auth/index.ts
@@ -1,0 +1,49 @@
+import * as aws from "@pulumi/aws";
+import * as docker from "@pulumi/docker";
+
+// Create a private ECR registry.
+const repo = new aws.ecr.Repository("my-repo", {
+    forceDelete: true,
+});
+
+// Get registry info (creds and endpoint) so we can build/publish to it.
+const registryInfo = repo.registryId.apply(async id => {
+    const credentials = await aws.ecr.getCredentials({ registryId: id });
+    const decodedCredentials = Buffer.from(credentials.authorizationToken, "base64").toString();
+    const [username, password] = decodedCredentials.split(":");
+    if (!password || !username) {
+        throw new Error("Invalid credentials");
+    }
+    return {
+        address: credentials.proxyEndpoint,
+        username: username,
+        password: password,
+    };
+});
+
+
+// Build image to simulate a local image
+const image = new docker.Image("my-image", {
+    build: {
+        context: "app",
+    },
+    imageName: repo.repositoryUrl,
+    skipPush: true
+});
+
+const ecrProvider = new docker.Provider("ecr-provider", {
+    registryAuth: [registryInfo],
+},
+);
+
+// Publish the image to the registry
+const registryImage = new docker.RegistryImage("my-registry-image",
+    {
+        name: repo.repositoryUrl,
+    },
+    { provider: ecrProvider, dependsOn: [image] },
+);
+
+// Export the resulting image name
+export const imageName = image.imageName;
+export const repoDigest = image.repoDigest;

--- a/examples/registry-token-auth/package.json
+++ b/examples/registry-token-auth/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "cbp-aws-ts",
+    "devDependencies": {
+        "@types/node": "^14.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.10.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/random": "^4.14.0"
+    }
+}

--- a/examples/registry-token-auth/tsconfig.json
+++ b/examples/registry-token-auth/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
The password and username of the registryAuth config can be volatile for many cloud registries. For AWS ECR you need to exchange AWS credentials for short lived tokens to authenticate to the registry.
This will lead to perma-diffs in the provider config.

This change adds a prototype to explore whether it's viable to ignore certain volatile fields of the registryAuth configuration.

fixes #952 