### PR TITLE
Remove random build ID

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -48,6 +48,8 @@ func TestDockerfileWithTarget(t *testing.T) {
 }
 
 func TestAzureContainerRegistry(t *testing.T) {
+	t.Skip("https://github.com/pulumi/pulumi-docker/issues/1238")
+
 	location := os.Getenv("AZURE_LOCATION")
 	if location == "" {
 		t.Skipf("Skipping test due to missing AZURE_LOCATION environment variable")

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestAzureContainerRegistryPy(t *testing.T) {
+	t.Skip("https://github.com/pulumi/pulumi-docker/issues/1238")
+
 	location := os.Getenv("AZURE_LOCATION")
 	if location == "" {
 		t.Skipf("Skipping test due to missing AZURE_LOCATION environment variable")

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/docker v25.0.2+incompatible
 	github.com/golang/protobuf v1.5.4
-	github.com/google/uuid v1.6.0
 	github.com/moby/buildkit v0.13.0-beta3.0.20240205165705-d6e142600ee5
 	github.com/moby/moby v25.0.4+incompatible
 	github.com/moby/patternmatcher v0.6.0
@@ -125,6 +124,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/google/wire v0.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.2 // indirect


### PR DESCRIPTION
This ID was added for diagnostics and we haven't seen any warnings reported so it should be safe to remove. More importantly the presence of the random label causes perpetual diffs, which is undesirable.

Fixes https://github.com/pulumi/pulumi-docker/issues/1219
Fixes https://github.com/pulumi/pulumi-docker/issues/1224
Refs https://github.com/pulumi/pulumi-docker/issues/846