### PR TITLE
Pin fsnotify/fsevents to v0.1.1 for darwin cross-compile

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -25,6 +25,7 @@ require (
 )
 
 replace (
+	github.com/fsnotify/fsevents => github.com/fsnotify/fsevents v0.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20260318212141-5525259d096b
 	github.com/terraform-providers/terraform-provider-docker => ../upstream
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -3166,8 +3166,8 @@ github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVB
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
-github.com/fsnotify/fsevents v0.2.0 h1:BRlvlqjvNTfogHfeBOFvSC9N0Ddy+wzQCQukyoD7o/c=
-github.com/fsnotify/fsevents v0.2.0/go.mod h1:B3eEk39i4hz8y1zaWS/wPrAP4O6wkIl7HQwKBr1qH/w=
+github.com/fsnotify/fsevents v0.1.1 h1:/125uxJvvoSDDBPen6yUZbil8J9ydKZnnl3TWWmvnkw=
+github.com/fsnotify/fsevents v0.1.1/go.mod h1:+d+hS27T6k5J8CRaPLKFgwKYcpS7GwW3Ule9+SC2ZRc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=


### PR DESCRIPTION
## Summary

Pin `github.com/fsnotify/fsevents` to v0.1.1 via a `replace` directive in `provider/go.mod`. v0.2.0 cannot be cross-compiled for darwin with `CGO_ENABLED=0`.

## Why

fsevents v0.2.0 splits its API across CGO build tags: the always-compiled `fsevents.go` (darwin-tagged) references symbols (`GetDeviceUUID`, `start`, `flush`, `stop`) that are only defined in a `darwin && cgo` tagged file. The provider Makefile cross-compiles darwin with `CGO_ENABLED=0` (see `scripts/crossbuild.mk:20-23`), so the CGO file is excluded and the references fail to resolve.

This broke master on 2026-05-11 when [terraform-provider-docker v4.3.0 was merged](https://github.com/pulumi/pulumi-docker/commit/0adbd92b) (#1697). PR #1697 was green because the PR check matrix only builds linux-amd64 and windows-amd64 — there is no darwin cross-build in `run-acceptance-tests.yml`, so the regression slipped through.

`gh run list --workflow=master.yml` shows three consecutive failed master runs since #1697 merged.

## Verification

Reproduced and verified locally with `GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build`:
- Before pin: `fsevents.go:147: undefined: GetDeviceUUID` (+ 3 other undefined symbols)
- After pin: clean compile through fsevents
- A/B confirmed by toggling the `replace` line on and off

I will also trigger `master.yml` via `workflow_dispatch` on this branch to run the full darwin matrix in CI before merging.

## Follow-up

The PR check matrix in `run-acceptance-tests.yml` should be expanded to include darwin-amd64 / darwin-arm64 so a future fsevents-style regression can be caught at PR time rather than post-merge. That belongs in `pulumi/ci-mgmt` since these workflows are autogenerated.

Tracked in pulumi/ci-mgmt#2233.

Part of #1698
