### PR TITLE
provider: log BuildKit session failure as warning, not error

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -229,7 +229,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		go func() {
 			err := sess.Run(ctx, dialSession)
 			if err != nil {
-				_ = p.host.Log(ctx, "error", urn, fmt.Sprintf("Error running BuildKit session: %v", err))
+				_ = p.host.Log(ctx, "warning", urn, fmt.Sprintf("Error running BuildKit session: %v", err))
 			}
 		}()
 		defer sess.Close()


### PR DESCRIPTION
## Summary

The BuildKit session goroutine in `runImageBuild` (`provider/image.go`) currently logs its failure at `error` severity. When the session can't be established (e.g., on podman), `runImageBuild` recovers by falling back to the legacy build path — the build still succeeds and the resource gets correct outputs.

Pulumi's engine treats an `error`-severity diagnostic on a resource as marking the resource errored, so users see a spurious failure on an otherwise-successful `docker.Image`.
Downgrading the severity to `warning` keeps the diagnostic visible without misrepresenting the resource state.

Fixes #1700.

Manual repro with before/after output in a follow-up comment.
