### PR TITLE
provider: log BuildKit session failure as warning, not error

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -229,7 +229,7 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		go func() {
 			err := sess.Run(ctx, dialSession)
 			if err != nil {
-				_ = p.host.Log(ctx, "error", urn, fmt.Sprintf("Error running BuildKit session: %v", err))
+				_ = p.host.Log(ctx, "warning", urn, fmt.Sprintf("Error running BuildKit session: %v", err))
 			}
 		}()
 		defer sess.Close()


### PR DESCRIPTION
The BuildKit session goroutine in runImageBuild runs independently of the
build itself. When it fails, runImageBuild falls back to the legacy build
path and the resource still succeeds with correct outputs.

Drop the severity to "warning" so the diagnostic remains visible without
marking the resource as broken.

Fixes #1700
