### PR TITLE
provider: prefer push-response digest for repoDigest output

### DIFF
--- a/provider/image.go
+++ b/provider/image.go
@@ -317,30 +317,14 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 
 	defer pushOutput.Close()
 
-	// TODO: https://github.com/pulumi/pulumi-docker/issues/846 - Consider relying on the PushResult
-	// for computing the repo digest.
 	var expectedRepoDigest reference.Reference
 	extractRepoDigest := func(rm json.RawMessage) (bool, string, error) {
-		var result types.PushResult
-		err := json.Unmarshal(rm, &result)
-		if err != nil {
-			// Unmarshal failures here mean the message isn't what we expected, return handled = false
-			return false, "", nil
+		ref, msg := parseRepoDigestFromAux(rm, imageName)
+		if ref == nil {
+			return false, msg, nil
 		}
-
-		digest, err := digest.Parse(result.Digest)
-		if err != nil {
-			return false, fmt.Sprintf("Unable to parse pushed digest %q", result.Digest), nil
-		}
-
-		imageNameWithoutTag := reference.TrimNamed(imageName) // removes tags or digests
-		pushedRepoDigest, err := reference.WithDigest(imageNameWithoutTag, digest)
-		if err != nil {
-			return false, fmt.Sprintf("Unable to compute expected repo digest from imageName %q, digest %q",
-				imageName.String(), result.Digest), nil
-		}
-		expectedRepoDigest = pushedRepoDigest
-		return true, fmt.Sprintf("Pushed image with digest %s", result.Digest), nil
+		expectedRepoDigest = ref
+		return true, msg, nil
 	}
 
 	// Print push logs to `Info` progress report
@@ -349,20 +333,24 @@ func (p *dockerNativeProvider) dockerBuild(ctx context.Context,
 		return "", nil, fmt.Errorf("error reading push output: %v", err)
 	}
 
-	// n.b.: This is one of the few API calls where we can use imageID and not img.Name, as it
-	// inspects the local store.
-	repoDigest, err := p.getRepoDigest(ctx, docker, imageID, img, urn)
-	if err != nil {
-		return "", nil, err
+	// Prefer the digest reported by the push response: it pins the image to the registry,
+	// which matches the intended meaning of repoDigest. Fall back to inspecting the local
+	// store only when the daemon did not emit an aux digest — the local-store digest is
+	// not guaranteed to match the registry digest (see containers/podman#14779).
+	var repoDigest reference.Reference
+	if expectedRepoDigest != nil {
+		repoDigest = expectedRepoDigest
+	} else {
+		_ = p.host.Log(ctx, "warning", urn,
+			"Push completed without reporting a digest; falling back to local image inspect")
+		// n.b.: This is one of the few API calls where we can use imageID and not img.Name, as it
+		// inspects the local store.
+		repoDigest, err = p.getRepoDigest(ctx, docker, imageID, img, urn)
+		if err != nil {
+			return "", nil, err
+		}
 	}
 	outputs["repoDigest"] = repoDigest.String()
-
-	if expectedRepoDigest == nil {
-		_ = p.host.Log(ctx, "warning", urn, "Push completed without reporting a digest")
-	} else if expectedRepoDigest.String() != repoDigest.String() {
-		_ = p.host.Log(ctx, "warning", urn,
-			fmt.Sprintf("Expected repo digest %q, found %q", expectedRepoDigest, repoDigest))
-	}
 
 	pbstruct, err := plugin.MarshalProperties(
 		resource.NewPropertyMapFromMap(outputs),
@@ -408,6 +396,27 @@ func (p *dockerNativeProvider) getRepoDigest(
 		}
 	}
 	return repoDigest, err
+}
+
+// parseRepoDigestFromAux parses the aux JSON emitted on the push stream into a
+// registry-pinned repo digest of the form <imageName>@<digest>. It returns a nil
+// reference when the message is not a parsable PushResult or its digest is invalid.
+// The status string is suitable for logging when non-empty.
+func parseRepoDigestFromAux(rm json.RawMessage, imageName reference.Named) (reference.Reference, string) {
+	var result types.PushResult
+	if err := json.Unmarshal(rm, &result); err != nil {
+		return nil, ""
+	}
+	d, err := digest.Parse(result.Digest)
+	if err != nil {
+		return nil, fmt.Sprintf("Unable to parse pushed digest %q", result.Digest)
+	}
+	pushedRepoDigest, err := reference.WithDigest(reference.TrimNamed(imageName), d)
+	if err != nil {
+		return nil, fmt.Sprintf("Unable to compute expected repo digest from imageName %q, digest %q",
+			imageName.String(), result.Digest)
+	}
+	return pushedRepoDigest, fmt.Sprintf("Pushed image with digest %s", result.Digest)
 }
 
 // runImageBuild runs the image build and ensures that the correct image exists in the local image

--- a/provider/image_test.go
+++ b/provider/image_test.go
@@ -2,11 +2,13 @@ package provider
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/build"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -734,4 +736,67 @@ func TestDockerIgnore(t *testing.T) {
 			assert.Equal(t, tt.want, actual)
 		})
 	}
+}
+
+func TestParseRepoDigestFromAux(t *testing.T) {
+	const validDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	mustParse := func(t *testing.T, name string) reference.Named {
+		t.Helper()
+		ref, err := reference.ParseNormalizedNamed(name)
+		require.NoError(t, err)
+		return ref
+	}
+
+	t.Run("valid push result returns registry-pinned digest", func(t *testing.T) {
+		imageName := mustParse(t, "docker.io/example/app:v1")
+		aux, err := json.Marshal(map[string]interface{}{
+			"Tag":    "v1",
+			"Digest": validDigest,
+			"Size":   1234,
+		})
+		require.NoError(t, err)
+
+		ref, msg := parseRepoDigestFromAux(aux, imageName)
+		require.NotNil(t, ref)
+		assert.Equal(t, "docker.io/example/app@"+validDigest, ref.String())
+		assert.Contains(t, msg, validDigest)
+	})
+
+	t.Run("input image name with tag is trimmed before applying digest", func(t *testing.T) {
+		imageName := mustParse(t, "registry.example.com/team/app:v2")
+		aux, err := json.Marshal(map[string]interface{}{"Digest": validDigest})
+		require.NoError(t, err)
+
+		ref, _ := parseRepoDigestFromAux(aux, imageName)
+		require.NotNil(t, ref)
+		assert.Equal(t, "registry.example.com/team/app@"+validDigest, ref.String())
+	})
+
+	t.Run("non-JSON aux message returns nil with no log", func(t *testing.T) {
+		imageName := mustParse(t, "docker.io/example/app:v1")
+		ref, msg := parseRepoDigestFromAux([]byte("not json at all"), imageName)
+		assert.Nil(t, ref)
+		assert.Empty(t, msg)
+	})
+
+	t.Run("malformed digest returns nil with diagnostic message", func(t *testing.T) {
+		imageName := mustParse(t, "docker.io/example/app:v1")
+		aux, err := json.Marshal(map[string]interface{}{"Digest": "not-a-digest"})
+		require.NoError(t, err)
+
+		ref, msg := parseRepoDigestFromAux(aux, imageName)
+		assert.Nil(t, ref)
+		assert.Contains(t, msg, "not-a-digest")
+	})
+
+	t.Run("empty digest returns nil with diagnostic message", func(t *testing.T) {
+		imageName := mustParse(t, "docker.io/example/app:v1")
+		aux, err := json.Marshal(map[string]interface{}{"Tag": "v1"})
+		require.NoError(t, err)
+
+		ref, msg := parseRepoDigestFromAux(aux, imageName)
+		assert.Nil(t, ref)
+		assert.NotEmpty(t, msg)
+	})
 }


### PR DESCRIPTION
When the push aux trailer contains a digest, use it directly. The aux value
is the registry-pinned manifest digest, which is the intended meaning of
repoDigest. Local ImageInspect returns the local-store digest, which is not
guaranteed to match the registry digest (most notably on podman, where the
two legitimately differ - see containers/podman#14779).

Fall back to ImageInspect when the daemon does not emit aux on the push
stream, preserving backwards compatibility with older daemons. Lift the aux
JSON parsing into a small testable helper and remove the now-dead divergence
warning that exists only to flag this exact divergence.

Fixes #846
